### PR TITLE
Trim textline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,8 @@ New Features:
 - new feature: control.set_skip_wait_functions
 - new feature: too long text lines will be trimmed automatically if the 
   max_width parameter has been defiend
+- new feature: too long words in text boxes will be trimmed automatically, 
+  this function can be switch off
 
 Changed:
 - changes at Simon example

--- a/expyriment/io/_textmenu.py
+++ b/expyriment/io/_textmenu.py
@@ -145,10 +145,11 @@ class TextMenu(Input):
         self._original_items = menu_items
         self._menu_items = []
         for item in menu_items:
-            self._menu_items.append(expyriment.stimuli.TextLine(
+            self._menu_items.append(expyriment.stimuli.TextBox(
                 "{0}".format(item),
                 text_size=text_size, text_font=text_font,
-                max_width=self._line_size[0]))
+                text_justification=justification,
+                size=self._line_size))
             expyriment.stimuli._stimulus.Stimulus._id_counter -= 1
         self._heading = expyriment.stimuli.TextBox(
             heading,

--- a/expyriment/stimuli/_textline.py
+++ b/expyriment/stimuli/_textline.py
@@ -63,7 +63,7 @@ class TextLine(Visual):
         max_width: int, optional
             maximum surface width of the text line stimulus
             if this parameter is defined, text lines that exceed this
-            surface width will be trimmed (indicated by a '~' as last letter).
+            surface width will be trimmed (indicated by a '~' as last letter)
 
         """
 

--- a/expyriment/stimuli/defaults.py
+++ b/expyriment/stimuli/defaults.py
@@ -43,6 +43,7 @@ textbox_text_justification = 1
 textbox_text_colour = None  # 'None' is experiment_text_colour
 textbox_background_colour = None  # 'None' is transparent
 textbox_position = (0, 0)
+textbox_do_not_trim_words = False
 
 # TextScreen
 textscreen_heading_font = None  # 'None' is experiment_heading_font


### PR DESCRIPTION
Hi Florian,

I guess trimming of too long text lines and word ins text boxes is a nice feature that also makes it easy to handle the recent bug in Android text_menu. Timing happens only if a width is defined. Thus, it occurs automatically for Textbox (but can be switch off) and for text_line, if a width is defined.
Please approve and merge.

Oliver
