### PR TITLE
small workaround to be able to run the test suite on computers with French Keyboards

### DIFF
--- a/examples/check-audio-visual-timing.py
+++ b/examples/check-audio-visual-timing.py
@@ -1,0 +1,67 @@
+#! /usr/bin/env python
+# -*- coding: utf-8 -*-
+# Time-stamp: <2016-04-23 10:47:53 chrplr>
+
+''' Display two white squares in alternance and play sounds simultanously, 
+to check timing with external equipment (oscilloscope, BlackBox ToolKit, ...) '''
+
+import expyriment
+
+exp = expyriment.design.Experiment(name="Cross-modal-timing-test")
+expyriment.control.initialize(exp)
+
+## setup
+square_top = expyriment.stimuli.Rectangle((100, 100), position=(0, 200))
+square_bottom = expyriment.stimuli.Rectangle((100, 100), position=(0, -200))
+tone1 = expyriment.stimuli.Tone(100, 440)
+tone2 = expyriment.stimuli.Tone(100, 880)
+
+square_top.preload()
+square_bottom.preload()
+tone1.preload()
+tone2.preload()
+
+SOA = 20 * (1000 * 1/60.) - 5 # a bit less than 10 frames at 1/60Hz
+NCYCLES = 10 
+
+frame = expyriment.stimuli.Canvas((600, 600))
+msg = expyriment.stimuli.TextScreen("", "Display two white squares for in alternance \n and play sounds simultanously, \n to check timing with external equipment \n (oscilloscope, Blackbox toolkit, etc.)", position=(0,-100))
+msg.plot(frame)
+square_top.plot(frame)
+square_bottom.plot(frame)
+
+
+## run
+expyriment.control.start(skip_ready_screen=True)
+
+exp.screen.clear()
+frame.present()
+exp.keyboard.wait()
+
+
+clok = expyriment.misc.Clock()
+
+for i in range(NCYCLES * 3):
+
+    while (clok.time < (SOA * i)):
+        pass
+
+    if (i % 3) == 0:
+       exp.screen.clear()
+       t = 0 # ?
+    elif (i % 3) == 1: 
+        tone1.play()
+        t = square_top.present()
+    else:
+        tone2.play()
+        t = square_bottom.present()
+ 
+    clok.wait(SOA - t)
+
+    exp.data.add([clok.time])
+    exp.keyboard.process_control_keys()
+
+
+## finish
+expyriment.control.end()
+

--- a/expyriment/control/_test_suite.py
+++ b/expyriment/control/_test_suite.py
@@ -195,19 +195,14 @@ After the test, you will be asked to indicate which (if any) of those two square
         inaccuracy = int(round(sum(inaccuracies)/float(len(inaccuracies))))
         delayed = round(100 * delayed_presentations/180.0, 2)
 
+        respkeys = {constants.K_F1:0, constants.K_F2:1, constants.K_F3:2,
+                    constants.K_0:0, constants.K_1:1, constants.K_2:2}
         text = stimuli.TextScreen(
             "How many of the two squares were flickering?",
-            "[Press 0, 1 or 2]")
+            "[Press 0 (or f1), 1 (or f2), 2 (or f3)]")
         text.present()
-        key, _rt = exp.keyboard.wait([constants.K_0,
-                                      constants.K_1,
-                                      constants.K_2])
-        if key == constants.K_0:
-            response = 0
-        elif key == constants.K_1:
-            response = 1
-        elif key == constants.K_2:
-            response = 2
+        key, _rt = exp.keyboard.wait(respkeys)
+        response = respkeys[key]
 
         info = stimuli.TextScreen("Results", "")
         results1 = stimuli.TextScreen("",


### PR DESCRIPTION
On French keyboards, one is blocked when running the visual part of the test suite because the keys '0' '1' and '2' are not accessible. I modified the script to also accept f1, f2 and f3.



