### PR TITLE
Fix for pyserial version 3.0.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -33,6 +33,7 @@ Fixed:
 - minor bug fixes in _secure_hash.py, _files.py
 - Cli: -0 option was not recognized
 - Correct anti-aliasing for Circle/Ellipse (now works on every background)
+- compatibility with pyserial version 3.0
 
 Version 0.8.0 (30 Jun 2015)
 ---------------------------

--- a/expyriment/io/_serialport.py
+++ b/expyriment/io/_serialport.py
@@ -21,8 +21,10 @@ from types import ModuleType
 
 try:
     import serial
+    from serial.tools.list_ports import comports as list_com_ports
 except:
     serial = None
+    list_com_ports = None
 
 from . import defaults
 from ._input_output import Input, Output
@@ -420,7 +422,7 @@ The Python package 'pySerial' is not installed."""
 
     @staticmethod
     def get_available_ports():
-        """Return an list of strings representing the available serial ports.
+        """Return a list of strings representing the available serial ports.
 
         Notes
         -----
@@ -435,44 +437,7 @@ The Python package 'pySerial' is not installed."""
 
         if not isinstance(serial, ModuleType):
             return None
-        ports = []
-        if platform.startswith("linux"): #for operation systems
-            dev = sorted(listdir('/dev'))
-            max_length = 0
-            for d in dev:
-                if d.startswith("tty") and len(d) > max_length:
-                    max_length = len(d)
-            for length in range(7, max_length + 1):
-                for p in dev:
-                    if p.startswith("ttyUSB") and len(p) == length:
-                        ports.append("/dev/" + p)
-            for length in range(5, max_length + 1):
-                for p in dev:
-                    if p.startswith("ttyS") and len(p) == length:
-                        ports.append("/dev/" + p)
-        elif platform == "darwin": #for MacOS
-            dev = sorted(listdir('/dev'))
-            max_length = 0
-            for d in dev:
-                if d.startswith("cu") and len(d) > max_length:
-                    max_length = len(d)
-            for length in range(13, max_length + 1):
-                for p in dev:
-                    if p.startswith("cu.usbserial") and len(p) == length:
-                        ports.append("/dev/" + p)
-            for length in range(5, max_length + 1):
-                for p in dev:
-                    if p.startswith("cuad") and len(p) == length:
-                        ports.append("/dev/" + p)
-        else: #for windows, os2
-            for p in range(256):
-                try:
-                    s = serial.Serial(p)
-                    if s.isOpen():
-                        ports.append(s.portstr)
-                        s.close()
-                except serial.SerialException:
-                    pass
+        ports = sorted([x[0] for x in list_com_ports()])
         return ports
 
     def send(self, data):

--- a/expyriment/io/_serialport.py
+++ b/expyriment/io/_serialport.py
@@ -90,7 +90,8 @@ class SerialPort(Input, Output):
 The Python package 'pySerial' is not installed."""
             raise ImportError(message)
 
-        if float(serial.VERSION) < 2.5:
+        serial_version = tuple(map(lambda x: int(x), serial.VERSION.split(".")))
+        if serial_version < (2, 5):
             raise ImportError("Expyriment {0} ".format(__version__) +
                     "is not compatible with PySerial {0}.".format(
                         serial.VERSION) +

--- a/expyriment/misc/_get_system_info.py
+++ b/expyriment/misc/_get_system_info.py
@@ -24,6 +24,7 @@ except ImportError:
     _ogl = None
 try:
     import serial as _serial
+    from serial.tools.list_ports import comports as _list_com_ports
 except ImportError:
     _serial = None
 try:
@@ -361,7 +362,7 @@ def get_system_info(as_string=False):
     info["hardware_ports_parallel"] = \
             ParallelPort.get_available_ports()
     info["hardware_ports_serial"] = \
-            SerialPort.get_available_ports()
+            _list_com_ports()
     info["hardware_video_card"] = hardware_video_card
 
     if as_string:


### PR DESCRIPTION
I changed the `get_available_ports()` method to list the first item in the objects returned by `serial.tools.list_ports.comports()` (i.e. the full device names only).

`misc.get_system_info()` will now return the full list (i.e. including descriptions of devices) from `serial.tools.list_ports.comports()`.