### PR TITLE
Fix unicode handling for textlines and pictures (#81)

### DIFF
--- a/expyriment/__init__.py
+++ b/expyriment/__init__.py
@@ -30,7 +30,7 @@ To cite Expyriment in publications, please refer to the following article:
 
 __author__ = 'Florian Krause <florian@expyriment.org>, \
 Oliver Lindemann <oliver@expyriment.org>'
-__version__ = '0.8.1.opensesame1'
+__version__ = '0.8.1.opensesame2'
 __revision__ = ''
 __date__ = ''
 

--- a/expyriment/__init__.py
+++ b/expyriment/__init__.py
@@ -30,7 +30,7 @@ To cite Expyriment in publications, please refer to the following article:
 
 __author__ = 'Florian Krause <florian@expyriment.org>, \
 Oliver Lindemann <oliver@expyriment.org>'
-__version__ = ''
+__version__ = '0.8.1.opensesame1'
 __revision__ = ''
 __date__ = ''
 

--- a/expyriment/misc/_miscellaneous.py
+++ b/expyriment/misc/_miscellaneous.py
@@ -240,19 +240,13 @@ def find_font(font):
     """
 
     pygame.font.init()
-
-    try:
-        if os.path.isfile(font):
-            pygame.font.Font(unicode2str(font, fse=True), 10)
-        else:
-            pygame.font.Font(unicode2str(font), 10)
+    if os.path.isfile(font):
         return font
-    except:
-        font_file = pygame.font.match_font(font)
-        if font_file is not None:
-            return font_file
-        else:
-            return ""
+    font_file = pygame.font.match_font(font)
+    if font_file is not None:
+        return font_file
+    else:
+        return ""
 
 def get_monitor_resolution():
     """Returns the monitor resolution

--- a/expyriment/stimuli/_picture.py
+++ b/expyriment/stimuli/_picture.py
@@ -67,8 +67,11 @@ class Picture(Visual):
     def _create_surface(self):
         """Create the surface of the stimulus."""
 
-        surface = pygame.image.load(unicode2str(self._filename,
-                                                fse=True)).convert_alpha()
+        # Due to a bug in handling of filenames in PyGame 1.9.2, we pass a file
+        # handle to PyGame. See also:
+        # - https://github.com/expyriment/expyriment/issues/81
+        with open(self._filename, "rb") as fd:
+            surface = pygame.image.load(fd).convert_alpha()
         if self._logging:
             expyriment._active_exp._event_file_log(
                 "Picture,loaded,{0}".format(unicode2str(self._filename)), 1)

--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ def remove_file(file_):
 
 if __name__=="__main__":
     # Check if we are building/installing from unreleased code
-    version_nr = get_version_from_file("expyriment/__init__.py")
+    version_nr = '0.8.1.opensesame1' #get_version_from_file("expyriment/__init__.py")
     warning = ""
     if version_nr == '':
         # Try to create html documentation

--- a/setup.py
+++ b/setup.py
@@ -191,7 +191,7 @@ def remove_file(file_):
 
 if __name__=="__main__":
     # Check if we are building/installing from unreleased code
-    version_nr = '0.8.1.opensesame1' #get_version_from_file("expyriment/__init__.py")
+    version_nr = '0.8.1.opensesame2' #get_version_from_file("expyriment/__init__.py")
     warning = ""
     if version_nr == '':
         # Try to create html documentation


### PR DESCRIPTION
I fixed part of the problem discussed in #81. For OpenSesame, things work fine now, but there are other references (notably to `pygame.font.Font`) that haven't been fixed and that still affect users of expyriment outside the context of OpenSesame.

My preference would be that you guys package and release this intermediate fix asap (as 0.8.1 probably), so that I can include it with OpenSesame 3.1. Then, when you guys have properly fixed all occurrences the issue, I will include that updated version (0.8.2 probably) with the first maintenance release of OpenSesame (i.e. 3.1.1).

Is that ok? I could also package it myself, but I prefer to stick with your packages.
