### PR TITLE
NEW: logging of inter-event-intervalls

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,12 @@ New Features:
 - rotate() method of stimuli applies filtering on the content now
 - randomize.coin_flip() with bias parameter ("unfair coins")
 - randomize.rand_norm() normally distributed random numbers
+- statistics module: std & variance
+- Eventfile.log has an optional log_event_tag for the logging of
+  inter-event-intervalls. If this is defined a summary of the intervalls
+  will be added to the event file.
+- All present methods have an optional log_event_tag that will be passed
+  to Eventfile.log (see above)
 
 Changed:
 - rename method: stimulus.replace --> stimulus.reposition

--- a/expyriment/design/_structure.py
+++ b/expyriment/design/_structure.py
@@ -948,14 +948,14 @@ type".format(permutation_type))
                                     self.blocks[block_cnt].trials[trial_cnt].\
                                         set_factor(trial_factors[col], val)
 
-    def _event_file_log(self, log_text, log_level=1):
+    def _event_file_log(self, log_text, log_level=1, log_event_tag=None):
         # log_level 1 = default, 2 = extensive, 0 or False = off
         """ Helper function to log event in the global experiment event file"""
         if self.is_initialized and\
                 self._log_level > 0 and\
                 self._log_level >= log_level and \
                 self.events is not None:
-            self.events.log(log_text)
+            self.events.log(event=log_text, log_event_tag=log_event_tag)
 
     def _event_file_warn(self, warning, log_level=1):
         """ Helper function to log event in the global experiment event file"""

--- a/expyriment/stimuli/_audio.py
+++ b/expyriment/stimuli/_audio.py
@@ -117,7 +117,7 @@ class Audio(Stimulus):
             self._file = None
             self._is_preloaded = False
 
-    def play(self, loops=0, maxtime=0, fade_ms=0):
+    def play(self, loops=0, maxtime=0, fade_ms=0, log_event_tag=None):
         """Play the audio stimulus.
 
         The function returns immediately after the sound started to play.
@@ -131,6 +131,10 @@ class Audio(Stimulus):
             stop after given amount of milliseconds (default = 0)
         fade_ms : int, optional
             fade in time in milliseconds (default = 0)
+        log_event_tag : numeral or string, optional
+            if log_event_tag is defined and if logging is switched on for this
+            stimulus (default), a summary of the inter-event-intervalls are
+            appended at the end of the event file
 
         """
 
@@ -145,7 +149,8 @@ class Audio(Stimulus):
                 filename = self._filename
 
             _internals.active_exp._event_file_log(
-                "Stimulus,played,{0}".format(filename), 1)
+                "Stimulus,played,{0}".format(filename), 1,
+                                 log_event_tag=log_event_tag)
         return rtn
 
     def stop(self):
@@ -154,7 +159,7 @@ class Audio(Stimulus):
         if self._is_preloaded:
             self._file.stop()
 
-    def present(self):
+    def present(self, log_event_tag=None):
         """Presents the sound.
 
         The function is identical to Audio.play(loops=0, maxtime=0, fade_ms=0)
@@ -166,4 +171,4 @@ class Audio(Stimulus):
 
         """
 
-        self.play()
+        self.play(log_event_tag=log_event_tag)

--- a/expyriment/stimuli/_video.py
+++ b/expyriment/stimuli/_video.py
@@ -219,9 +219,16 @@ class Video(_visual.Stimulus):
             self._surface = None
             self._is_preloaded = False
 
-    def play(self):
+    def play(self, log_event_tag=None):
         """Play the video stimulus from the current position.
         
+        Parameters
+        ----------
+        log_event_tag : numeral or string, optional
+            if log_event_tag is defined and if logging is switched on for this
+            stimulus (default), a summary of the inter-event-intervalls are
+            appended at the end of the event file
+
         Notes
         -----
         When the audio from the video should be played as well, the audiosystem
@@ -248,7 +255,8 @@ expyriment.control.stop_audiosystem() before preloading the video."
             self.preload()
         if self._logging:
             _internals.active_exp._event_file_log(
-                "Video,playing,{0}".format(unicode2byte(self._filename)))
+                "Video,playing,{0}".format(unicode2byte(self._filename)), 1,
+                log_event_tag=log_event_tag)
         self._file.play()
 
     def stop(self):
@@ -288,12 +296,19 @@ expyriment.control.stop_audiosystem() before preloading the video."
             self._file.rewind()
             self._frame = 0
 
-    def present(self):
+    def present(self, log_event_tag=None):
         """Play the video and present current frame.
 
         This method starts video playback and presents a single frame (the
         current one). When using OpenGL, the method blocks until this frame is
         actually being written to the screen.
+
+        Parameters
+        ----------
+        log_event_tag : numeral or string, optional
+            if log_event_tag is defined and if logging is switched on for this
+            stimulus (default), a summary of the inter-event-intervalls are
+            appended at the end of the event file
 
         Notes
         -----
@@ -309,7 +324,7 @@ expyriment.control.stop_audiosystem() before preloading the video."
         
         """
 
-        self.play()
+        self.play(log_event_tag=log_event_tag)
         while not self._file.get_frame() > self._frame:
             pass
         self.update()

--- a/expyriment/stimuli/_visual.py
+++ b/expyriment/stimuli/_visual.py
@@ -974,7 +974,7 @@ class Visual(Stimulus):
 
         return self._is_preloaded
 
-    def present(self, clear=True, update=True):
+    def present(self, clear=True, update=True, log_event_tag=None):
         """Present the stimulus on the screen.
 
         This clears and updates the screen automatically.
@@ -989,6 +989,10 @@ class Visual(Stimulus):
         update : bool, optional
             if False the screen will be not be updated automatically
             (default = True)
+        log_event_tag : numeral or string, optional
+            if log_event_tag is defined and if logging is switched on for this
+            stimulus (default), a summary of the inter-event-intervalls are
+            appended at the end of the event file
 
         Returns
         -------
@@ -1022,7 +1026,8 @@ class Visual(Stimulus):
             screen.blit(self._get_surface(), rect)
         if self._logging:
             _internals.active_exp._event_file_log("Stimulus,presented,{0}"\
-                                   .format(self.id), 1)
+                                   .format(self.id), 1,
+                                 log_event_tag=log_event_tag)
         if update:
             _internals.active_exp.screen.update()
         if preloading_required:


### PR DESCRIPTION
I find this a very handy method to check the time of your experiment.

Eventfile.log has an optional log_event_tag for the logging of inter-event-intervalls. If this is defined a summary of the intervalls will be added to the event file.  All present methods have an optional log_event_tag that will be passed to Eventfile.log (see above).

@fladd  What do you think?