### PR TITLE
Wait methods additions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,8 +28,8 @@ Changed:
 - all wait methods (io and Clock) now
     (1) have process_control_events attribute to check for quit events from
         keyboard and mouse
-    (2) have function attribute to repeatedly run a specific function in every
-        loop iteration
+    (2) have function attribute (callback_function) to repeatedly run a
+        specific function in every loop iteration
     (3) pump the pygame event queue to (hopefully) prevent the OS to think the
         window is "not responding"
 - control.set_develop_mode: new skip_wait_functions attribute to ommit all wait 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,15 @@ New Features:
   to Eventfile.log (see above)
 
 Changed:
+- all wait methods (io and Clock) now
+    (1) have process_control_events attribute to check for quit events from
+        keyboard and mouse
+    (2) have function attribute to repeatedly run a specific function in every
+        loop iteration
+    (3) pump the pygame event queue to (hopefully) prevent the OS to think the
+        window is "not responding"
+- control.set_develop_mode: new skip_wait_functions attribute to ommit all wait 
+  functions in the experiment (for testing)
 - rename method: stimulus.replace --> stimulus.reposition
 - improvements to io.extras.TcpClient
 - move set_skip_wait_functions from misc to io

--- a/expyriment/_internals.py
+++ b/expyriment/_internals.py
@@ -3,6 +3,7 @@
 This module also contains the currently active experiment:
             active_exp
 """
+
 from builtins import object
 
 __author__ = 'Florian Krause <florian@expyriment.org> \
@@ -11,19 +12,13 @@ __version__ = ''
 __revision__ = ''
 __date__ = ''
 
+
 import sys
 import os
 try:
     import android
 except ImportError:
     android = None
-
-PYTHON3 = (sys.version_info[0] == 3)
-
-###
-active_exp = None # expyriment.design.__init__ sets active_exp to design.Experiment("None")
-### Provides the access to the currently active experiment
-### import ._internals to read and write _active.exp
 
 
 def get_version():
@@ -46,6 +41,35 @@ def get_version():
             #no use of .major, .minor to ensure MacOS compatibility
     return "{0} (Python {1})".format(__version__, pv)
 
+
+# GLOBALLY NEEDED STUFF
+
+PYTHON3 = (sys.version_info[0] == 3)
+
+active_exp = None # expyriment.design.__init__ sets active_exp to
+                  # design.Experiment("None")
+                  # Provides the access to the currently active experiment
+                  # import ._internals to read and write _active.exp
+
+skip_wait_functions = False  # global toggle, can be changed by set_develop_mode
+
+def is_base_string(s):
+    if PYTHON3:
+        return isinstance(s, (str, bytes))
+    else:
+        return isinstance(s, (unicode, str))
+
+def is_unicode_string(s):
+    if PYTHON3:
+        return isinstance(s, str)
+    else:
+        return isinstance(s, unicode)
+
+def is_byte_string(s):
+    if PYTHON3:
+        return isinstance(s, bytes)
+    else:
+        return isinstance(s, str)
 
 class Expyriment_object(object):
     """A class implementing a general Expyriment object.
@@ -80,8 +104,6 @@ class Expyriment_object(object):
 
         return self._logging
 
-
-
 class CallbackQuitEvent(object):
     """A CallbackQuitEvent
 
@@ -111,9 +133,8 @@ class CallbackQuitEvent(object):
         return "CallbackQuitEvent: data={0}".format(self.data)
 
 
+# IMPORTER FUNCTIONS
 
-
-###   importer functions
 def import_command(path):
     # helper function to generate import command for extras that is Python2/3 compatible
     if PYTHON3:
@@ -272,20 +293,3 @@ def post_import_hook():
     else:
         return ""
 
-def is_base_string(s):
-    if PYTHON3:
-        return isinstance(s, (str, bytes))
-    else:
-        return isinstance(s, (unicode, str))
-
-def is_unicode_string(s):
-    if PYTHON3:
-        return isinstance(s, str)
-    else:
-        return isinstance(s, unicode)
-
-def is_byte_string(s):
-    if PYTHON3:
-        return isinstance(s, bytes)
-    else:
-        return isinstance(s, str)

--- a/expyriment/_internals.py
+++ b/expyriment/_internals.py
@@ -94,7 +94,7 @@ class Expyriment_object(object):
         See also design.experiment.set_log_level fur further information about
         event logging.
 
-    """
+        """
 
         self._logging = onoff
 

--- a/expyriment/control/_experiment_control.py
+++ b/expyriment/control/_experiment_control.py
@@ -303,7 +303,7 @@ def end(goodbye_text=None, goodbye_delay=None, confirmation=False,
                          text_colour=misc.constants.C_EXPYRIMENT_ORANGE,
                          text_size=24).present()
         stimuli._stimulus.Stimulus._id_counter -= 1
-        char = Keyboard().wait_char(["y", "n"], check_for_control_keys=False)
+        char = Keyboard().wait_char(["y", "n"], process_control_events=False)
         if char[0] == "n":
             experiment._screen.colour = screen_colour
             experiment._event_file_log("Experiment,resumed")

--- a/expyriment/control/_miscellaneous.py
+++ b/expyriment/control/_miscellaneous.py
@@ -89,7 +89,7 @@ def wait_end_audiosystem(channel=None):
                     io.Keyboard.process_control_keys(event)
 
 
-def set_develop_mode(onoff, intensive_logging=False):
+def set_develop_mode(onoff, intensive_logging=False, skip_wait_functions=False):
     """Set defaults for a more convenient develop mode.
 
     Notes
@@ -109,6 +109,9 @@ def set_develop_mode(onoff, intensive_logging=False):
     intensive_logging : bool, optional
         True sets expyriment.io.defaults.event_logging=2
         (default = False)
+    skip_wait_functions : bool, optional
+        If True, all wait functions in the experiment (i.e. all wait functions
+        in ``expyriment.io`` and the clock) will be ommited (default = False)
 
     """
 
@@ -142,6 +145,9 @@ def set_develop_mode(onoff, intensive_logging=False):
 
     if intensive_logging:
         defaults.event_logging = 2
+
+    _internals.skip_wait_functions = skip_wait_functions
+
 
 def _get_module_values(goal_dict, module):
     value = None

--- a/expyriment/io/__init__.py
+++ b/expyriment/io/__init__.py
@@ -15,7 +15,6 @@ __date__ = ''
 
 
 from . import defaults
-from ._input_output import set_skip_wait_functions
 from ._screen import Screen
 from ._keyboard import Keyboard
 from ._mouse import Mouse

--- a/expyriment/io/_gamepad.py
+++ b/expyriment/io/_gamepad.py
@@ -19,7 +19,6 @@ from .. import _internals
 from ..misc._timer import get_time
 from ._keyboard import Keyboard
 from  ._input_output import Input, Output
-from .defaults import _skip_wait_functions
 
 pygame.joystick.init()
 
@@ -230,7 +229,7 @@ class GamePad(Input, Output):
 
         """
 
-        if _skip_wait_functions:
+        if _internals.skip_wait_functions:
             return None, None
         start = get_time()
         rt = None

--- a/expyriment/io/_gamepad.py
+++ b/expyriment/io/_gamepad.py
@@ -13,8 +13,11 @@ __revision__ = ''
 __date__ = ''
 
 
-import pygame
 import time
+from types import FunctionType
+
+import pygame
+
 from .. import _internals
 from ..misc._timer import get_time
 from ._keyboard import Keyboard
@@ -204,7 +207,8 @@ class GamePad(Input, Output):
         if self._logging:
             _internals.active_exp._event_file_log("GamePad,cleared", 2)
 
-    def wait_press(self, buttons=None, duration=None):
+    def wait_press(self, buttons=None, duration=None, function=None,
+                   process_control_events=True):
         """Wait for gamepad button press.
 
         Returns the found button and the reaction time.
@@ -215,6 +219,11 @@ class GamePad(Input, Output):
             specific buttons to wait for
         duration : int, optional
             maximal time to wait in ms
+        function : function, optional
+            function to repeatedly execute during waiting loop
+        process_control_events : bool, optional
+            process ``io.Keyboard.process_control_keys()`` and
+            ``io.Mouse.process_quit_event()`` (default = True)
 
         Returns
         -------
@@ -243,19 +252,26 @@ class GamePad(Input, Output):
             buttons = [buttons]
         done = False
         while not done:
-            rtn_callback = _internals.active_exp._execute_wait_callback()
-            if isinstance(rtn_callback, _internals.CallbackQuitEvent):
-                _button = rtn_callback
-                rt = int((get_time() - start) * 1000)
-                done = True
-
+            if isinstance(function, FunctionType):
+                function()
+            if _internals.active_exp is not None and \
+               _internals.active_exp.is_initialized:
+                rtn_callback = _internals.active_exp._execute_wait_callback()
+                if isinstance(rtn_callback, _internals.CallbackQuitEvent):
+                    _button = rtn_callback
+                    rt = int((get_time() - start) * 1000)
+                    done = True
+                if process_control_events:
+                    if _internals.active_exp.mouse.process_quit_event() or \
+                       _internals.active_exp.keyboard.process_control_keys():
+                        done = True
             for button in buttons:
                 if self.get_button(button):
                     _button = button
                     rt = int((get_time() - start) * 1000)
                     done = True
                     break
-                if _button is not None or Keyboard.process_control_keys():
+                if _button is not None:
                     done = True
                     break
                 if duration:

--- a/expyriment/io/_gamepad.py
+++ b/expyriment/io/_gamepad.py
@@ -207,7 +207,7 @@ class GamePad(Input, Output):
         if self._logging:
             _internals.active_exp._event_file_log("GamePad,cleared", 2)
 
-    def wait_press(self, buttons=None, duration=None, function=None,
+    def wait_press(self, buttons=None, duration=None, callback_function=None,
                    process_control_events=True):
         """Wait for gamepad button press.
 
@@ -219,7 +219,7 @@ class GamePad(Input, Output):
             specific buttons to wait for
         duration : int, optional
             maximal time to wait in ms
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.Keyboard.process_control_keys()`` and
@@ -252,8 +252,8 @@ class GamePad(Input, Output):
             buttons = [buttons]
         done = False
         while not done:
-            if isinstance(function, FunctionType):
-                function()
+            if isinstance(callback_function, FunctionType):
+                callback_function()
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_input_output.py
+++ b/expyriment/io/_input_output.py
@@ -6,6 +6,7 @@ This module contains the base classes for input and output.
 All classes in this module should be called directly via expyriment.io.*.
 
 """
+
 from __future__ import absolute_import, print_function, division
 
 __author__ = 'Florian Krause <florian@expyriment.org>, \
@@ -14,8 +15,10 @@ __version__ = ''
 __revision__ = ''
 __date__ = ''
 
+
 from . import defaults
 from .._internals import Expyriment_object
+
 
 class Input(Expyriment_object):
     """A class implementing a general input."""
@@ -31,24 +34,3 @@ class Output(Expyriment_object):
     def __init__(self):
         """Create an output."""
         Expyriment_object.__init__(self)
-
-
-def set_skip_wait_functions(onoff):
-    """Switch on/off skip wait function.
-    If skip-wait-functions is switch on (True) all wait functions in the
-    experiment (i.e.  all wait function in expyriment.io and the clock) will
-    be omitted.
-
-    Notes
-    -----
-    CAUTION!: This functions is only usefull for experiment test runs. Do not use
-    skip-wait-function while real experiments.
-
-    Parameters
-    ----------
-    onoff : bool
-        set skip-wait-function on (True) or off (False)
-
-    """
-
-    defaults._skip_wait_functions = onoff

--- a/expyriment/io/_keyboard.py
+++ b/expyriment/io/_keyboard.py
@@ -245,7 +245,7 @@ class Keyboard(Input):
 
         """
 
-        if defaults._skip_wait_functions:
+        if _internals.skip_wait_functions:
             return None, None
         if android_show_keyboard is not None:
             android_show_keyboard()
@@ -324,7 +324,7 @@ class Keyboard(Input):
 
         """
 
-        if defaults._skip_wait_functions:
+        if _internals.skip_wait_functions:
             return None, None
         start = get_time()
         rt = None

--- a/expyriment/io/_keyboard.py
+++ b/expyriment/io/_keyboard.py
@@ -211,7 +211,7 @@ class Keyboard(Input):
         return None
 
     def wait(self, keys=None, duration=None, wait_for_keyup=False,
-             function=None, process_control_events=True):
+             callback_function=None, process_control_events=True):
         """Wait for keypress(es) (optionally for a certain amount of time).
 
         This function will wait for a keypress and returns the found key as
@@ -226,7 +226,7 @@ class Keyboard(Input):
             maximal time to wait in ms
         wait_for_keyup : bool, optional
             if True it waits for key-up
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.Keyboard.process_control_keys()`` and
@@ -271,8 +271,8 @@ class Keyboard(Input):
         pygame.event.pump()
         done = False
         while not done:
-            if isinstance(function, FunctionType):
-                function()
+            if isinstance(callback_function, FunctionType):
+                callback_function
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()
@@ -308,7 +308,7 @@ class Keyboard(Input):
             android_hide_keyboard()
         return found_key, rt
 
-    def wait_char(self, char, duration=None, function=None,
+    def wait_char(self, char, duration=None, callback_function=None,
                   process_control_events=True):
         """Wait for character(s) (optionally for a certain amount of time).
 
@@ -322,7 +322,7 @@ class Keyboard(Input):
             a specific character or list of characters to wait for
         duration : int, optional
             maximal time to wait in ms
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.Keyboard.process_control_keys()`` and
@@ -331,7 +331,7 @@ class Keyboard(Input):
         Returns
         -------
         found : char
-            pressed charater
+            pressed character
         rt : int
             reaction time in ms
 
@@ -355,8 +355,8 @@ class Keyboard(Input):
         done = False
 
         while not done:
-            if isinstance(function, FunctionType):
-                function()
+            if isinstance(callback_function, FunctionType):
+                callback_function()
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_keyboard.py
+++ b/expyriment/io/_keyboard.py
@@ -369,7 +369,7 @@ class Keyboard(Input):
             for event in pygame.event.get([pygame.KEYUP, pygame.KEYDOWN]):
                 if _internals.active_exp is not None and \
                    _internals.active_exp.is_initialized and \
-                   check_for_control_keys and \
+                   process_control_events and \
                    Keyboard.process_control_keys(event):
                     done = True
                 elif event.type == pygame.KEYDOWN:

--- a/expyriment/io/_keyboard.py
+++ b/expyriment/io/_keyboard.py
@@ -15,6 +15,7 @@ __date__ = ''
 
 
 import time, sys
+from types import FunctionType
 
 import pygame
 
@@ -175,7 +176,7 @@ class Keyboard(Input):
         keys : int or list, optional
             a specific key or list of keys to check
         check_for_control_keys : bool, optional
-            checks if control key has been pressed (default=True)
+            checks if control key has been pressed (default = True)
 
         Returns
         -------
@@ -210,7 +211,7 @@ class Keyboard(Input):
         return None
 
     def wait(self, keys=None, duration=None, wait_for_keyup=False,
-             check_for_control_keys=True):
+             function=None, process_control_events=True):
         """Wait for keypress(es) (optionally for a certain amount of time).
 
         This function will wait for a keypress and returns the found key as
@@ -225,8 +226,11 @@ class Keyboard(Input):
             maximal time to wait in ms
         wait_for_keyup : bool, optional
             if True it waits for key-up
-        check_for_control_keys : bool, optional
-            checks if control key has been pressed (default=True)
+        function : function, optional
+            function to repeatedly execute during waiting loop
+        process_control_events : bool, optional
+            process ``io.Keyboard.process_control_keys()`` and
+            ``io.Mouse.process_quit_event()`` (default = True)
 
         Returns
         -------
@@ -267,13 +271,22 @@ class Keyboard(Input):
         pygame.event.pump()
         done = False
         while not done:
-            rtn_callback = _internals.active_exp._execute_wait_callback()
-            if isinstance(rtn_callback, _internals.CallbackQuitEvent):
-                done = True
-                found_key = rtn_callback
-                rt = int((get_time() - start) * 1000)
+            if isinstance(function, FunctionType):
+                function()
+            if _internals.active_exp is not None and \
+               _internals.active_exp.is_initialized:
+                rtn_callback = _internals.active_exp._execute_wait_callback()
+                if isinstance(rtn_callback, _internals.CallbackQuitEvent):
+                    done = True
+                    found_key = rtn_callback
+                    rt = int((get_time() - start) * 1000)
+                if process_control_events:
+                    _internals.active_exp.mouse.process_quit_event()
             for event in pygame.event.get([pygame.KEYDOWN, pygame.KEYUP]):
-                if check_for_control_keys and Keyboard.process_control_keys(event):
+                if _internals.active_exp is not None and \
+                   _internals.active_exp.is_initialized and \
+                   process_control_events and \
+                   Keyboard.process_control_keys(event):
                     done = True
                 elif event.type == target_event:
                     if keys is not None:
@@ -295,7 +308,8 @@ class Keyboard(Input):
             android_hide_keyboard()
         return found_key, rt
 
-    def wait_char(self, char, duration=None, check_for_control_keys=True):
+    def wait_char(self, char, duration=None, function=None,
+                  process_control_events=True):
         """Wait for character(s) (optionally for a certain amount of time).
 
         This function will wait for one or more characters and returns the
@@ -308,8 +322,11 @@ class Keyboard(Input):
             a specific character or list of characters to wait for
         duration : int, optional
             maximal time to wait in ms
-        check_for_control_keys : bool, optional
-            checks if control key has been pressed (default=True)
+        function : function, optional
+            function to repeatedly execute during waiting loop
+        process_control_events : bool, optional
+            process ``io.Keyboard.process_control_keys()`` and
+            ``io.Mouse.process_quit_event()`` (default = True)
 
         Returns
         -------
@@ -338,14 +355,22 @@ class Keyboard(Input):
         done = False
 
         while not done:
-            rtn_callback = _internals.active_exp._execute_wait_callback()
-            if isinstance(rtn_callback, _internals.CallbackQuitEvent):
-                    done = True
-                    rt = int((get_time() - start) * 1000)
-                    found_char = rtn_callback
-
+            if isinstance(function, FunctionType):
+                function()
+            if _internals.active_exp is not None and \
+               _internals.active_exp.is_initialized:
+                rtn_callback = _internals.active_exp._execute_wait_callback()
+                if isinstance(rtn_callback, _internals.CallbackQuitEvent):
+                        done = True
+                        rt = int((get_time() - start) * 1000)
+                        found_char = rtn_callback
+                if process_control_events:
+                    _internals.active_exp.mouse.process_quit_event()
             for event in pygame.event.get([pygame.KEYUP, pygame.KEYDOWN]):
-                if check_for_control_keys and Keyboard.process_control_keys(event):
+                if _internals.active_exp is not None and \
+                   _internals.active_exp.is_initialized and \
+                   check_for_control_keys and \
+                   Keyboard.process_control_keys(event):
                     done = True
                 elif event.type == pygame.KEYDOWN:
                     if event.unicode in char:

--- a/expyriment/io/_mouse.py
+++ b/expyriment/io/_mouse.py
@@ -445,7 +445,7 @@ class Mouse(Input):
 
         """
 
-        if defaults._skip_wait_functions:
+        if _internals.skip_wait_functions:
             return None, None, None, None
         start = get_time()
         self.clear()

--- a/expyriment/io/_mouse.py
+++ b/expyriment/io/_mouse.py
@@ -406,7 +406,7 @@ class Mouse(Input):
 
     def wait_event(self, wait_button=True, wait_motion=True, buttons=None,
                    duration=None, wait_for_buttonup=False,
-                   function=None, process_control_events=True):
+                   callback_function=None, process_control_events=True):
         """Wait for a mouse event (i.e., motion, button press or wheel event)
 
         Parameters
@@ -421,7 +421,7 @@ class Mouse(Input):
             the maximal time to wait in ms
         wait_for_buttonup : bool, optional
             if True it waits for button-up default=False)
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.keyboard.process_control_keys()`` and
@@ -469,8 +469,8 @@ class Mouse(Input):
             except:
                 buttons = [buttons]
         while True:
-            if isinstance(function, FunctionType):
-                function()
+            if isinstance(callback_function, FunctionType):
+                callback_function()
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()
@@ -508,7 +508,7 @@ class Mouse(Input):
 
 
     def wait_press(self, buttons=None, duration=None, wait_for_buttonup=False,
-                   function=None, process_control_events=True):
+                   callback_function=None, process_control_events=True):
         """Wait for a mouse button press or mouse wheel event.
 
         Parameters
@@ -519,7 +519,7 @@ class Mouse(Input):
             maximal time to wait in ms
         wait_for_buttonup : bool, optional
             if True it waits for button-up
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.keyboard.process_control_keys()`` and
@@ -548,11 +548,11 @@ class Mouse(Input):
         rtn = self.wait_event(wait_button=True, wait_motion=False,
                               buttons=buttons, duration=duration,
                               wait_for_buttonup=wait_for_buttonup,
-                              function=function,
+                              callback_function=callback_function,
                               process_control_events=process_control_events)
         return rtn[0], rtn[2], rtn[3]
 
-    def wait_motion(self, duration=None, function=None,
+    def wait_motion(self, duration=None, callback_function=None,
                     process_control_events=True):
         """Wait for a mouse motion.
 
@@ -560,7 +560,7 @@ class Mouse(Input):
         ----------
         duration : int, optional
             maximal time to wait in ms
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.keyboard.process_control_keys()`` and
@@ -579,7 +579,7 @@ class Mouse(Input):
 
         rtn = self.wait_event(wait_button=False, wait_motion=True, buttons=[],
                               duration=duration, wait_for_buttonup=False,
-                              function=function,
+                              callback_function=callback_function,
                               process_control_events=process_control_events)
 
         if isinstance(rtn[0], _internals.CallbackQuitEvent):

--- a/expyriment/io/_mouse.py
+++ b/expyriment/io/_mouse.py
@@ -508,7 +508,7 @@ class Mouse(Input):
 
 
     def wait_press(self, buttons=None, duration=None, wait_for_buttonup=False,
-                   function=None, process_quit_events=True):
+                   function=None, process_control_events=True):
         """Wait for a mouse button press or mouse wheel event.
 
         Parameters

--- a/expyriment/io/_streamingbuttonbox.py
+++ b/expyriment/io/_streamingbuttonbox.py
@@ -152,7 +152,7 @@ class StreamingButtonBox(Input, Output):
 
         """
 
-        if defaults._skip_wait_functions:
+        if _internals.skip_wait_functions:
             return None, None
         start = get_time()
         rt = None

--- a/expyriment/io/_streamingbuttonbox.py
+++ b/expyriment/io/_streamingbuttonbox.py
@@ -113,13 +113,13 @@ class StreamingButtonBox(Input, Output):
                 return None
 
     def wait(self, codes=None, duration=None, no_clear_buffer=False,
-             bitwise_comparison=False, function=None,
+             bitwise_comparison=False, callback_function=None,
              process_control_events=True):
         """Wait for responses defined as codes.
 
         Notes
         -----
-        If bitwise_comparision = True, the function performs a bitwise
+        If bitwise_comparison = True, the function performs a bitwise
         comparison (logical and) between codes and received input and waits
         until a certain bit pattern is set.
 
@@ -139,7 +139,7 @@ class StreamingButtonBox(Input, Output):
             do not clear the buffer (default = False)
         bitwise_comparison : bool, optional
             make a bitwise comparison (default = False)
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.Keyboard.process_control_keys()`` and
@@ -148,7 +148,7 @@ class StreamingButtonBox(Input, Output):
         Returns
         -------
         key : int
-            key code (or None) that quitted waiting
+            key code (or None) that quited waiting
         rt : int
             reaction time
 
@@ -165,8 +165,8 @@ class StreamingButtonBox(Input, Output):
         if not no_clear_buffer:
             self.clear()
         while True:
-            if isinstance(function, FunctionType):
-                function()
+            if isinstance(callback_function, FunctionType):
+                callback_function()
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_touchscreenbuttonbox.py
+++ b/expyriment/io/_touchscreenbuttonbox.py
@@ -223,8 +223,8 @@ class TouchScreenButtonBox(Input):
                 return bf
         return None
 
-    def wait(self, duration=None, button_fields=None, function=None,
-                process_control_keys=True):
+    def wait(self, duration=None, button_fields=None, callback_function=None,
+                process_control_events=True):
         """Wait for a touchscreen button box click.
 
         Parameters
@@ -233,7 +233,7 @@ class TouchScreenButtonBox(Input):
             The button fields that will be checked for.
         duration : int, optional
             maximal time to wait in ms
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.Keyboard.process_control_keys()`` and
@@ -261,8 +261,8 @@ class TouchScreenButtonBox(Input):
         start = get_time()
         self.clear_event_buffer()
         while True:
-            if isinstance(function, FunctionType):
-                function()
+            if isinstance(callback_function, FunctionType):
+                callback_function()
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_touchscreenbuttonbox.py
+++ b/expyriment/io/_touchscreenbuttonbox.py
@@ -17,9 +17,8 @@ __date__ = ''
 from .. import _internals, stimuli
 from ._keyboard import Keyboard
 from ..misc._timer import get_time
-from .._internals import CallbackQuitEvent
+from .._internals import CallbackQuitEvent, skip_wait_functions
 from ._input_output import Input
-from .defaults import _skip_wait_functions
 
 class TouchScreenButtonBox(Input):
     """A class implementing a TouchScreenButtonBox."""
@@ -253,7 +252,7 @@ class TouchScreenButtonBox(Input):
 
         """
 
-        if _skip_wait_functions:
+        if skip_wait_functions:
             return None, None
         start = get_time()
         self.clear_event_buffer()

--- a/expyriment/io/_triggerinput.py
+++ b/expyriment/io/_triggerinput.py
@@ -60,7 +60,7 @@ class TriggerInput(Input):
         """Getter for default_code"""
         self._default_code = value
 
-    def wait(self, code=None, bitwise_comparison=False, function=None,
+    def wait(self, code=None, bitwise_comparison=False, callback_function=None,
              process_control_events=True):
         """Wait for a trigger.
 
@@ -97,8 +97,8 @@ class TriggerInput(Input):
             code = self._default_code
         self.interface.clear()
         while True:
-            if isinstance(function, FunctionType):
-                function()
+            if isinstance(callback_function, FunctionType):
+                callback_function()
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_triggerinput.py
+++ b/expyriment/io/_triggerinput.py
@@ -14,10 +14,12 @@ __revision__ = ''
 __date__ = ''
 
 
+from types import FunctionType
+
 from . import defaults
 from .. import _internals
 from ..misc import compare_codes
-from .._internals import CallbackQuitEvent, skip_wait_functions
+from .._internals import CallbackQuitEvent
 from ..misc._timer import get_time
 from ._keyboard import Keyboard
 from  ._input_output import Input
@@ -58,7 +60,8 @@ class TriggerInput(Input):
         """Getter for default_code"""
         self._default_code = value
 
-    def wait(self, code=None, bitwise_comparison=False):
+    def wait(self, code=None, bitwise_comparison=False, function=None,
+             process_control_events=True):
         """Wait for a trigger.
 
         Returns the code received and the reaction time [code, rt].
@@ -68,8 +71,16 @@ class TriggerInput(Input):
         until a certain bit pattern is set.
 
         Parameters
-        code -- a specific code to wait for (int) (optional)
-        bitwise_comparison -- make a bitwise comparison (default=False)
+        ----------
+        code : int, optional
+            a specific code to wait for
+        bitwise_comparison : bool, optional
+            make a bitwise comparison (default = False)
+        function : function, optional
+            function to repeatedly execute during waiting loop
+        process_control_events : bool, optional
+            process ``io.Keyboard.process_control_keys()`` and
+            ``io.Mouse.process_quit_event()`` (default = True)
 
         See Also
         --------
@@ -77,7 +88,7 @@ class TriggerInput(Input):
 
        """
 
-        if skip_wait_functions:
+        if _internals.skip_wait_functions:
             return None, None
         start = get_time()
         found = None
@@ -86,9 +97,20 @@ class TriggerInput(Input):
             code = self._default_code
         self.interface.clear()
         while True:
-            rtn_callback = _internals.active_exp._execute_wait_callback()
-            if isinstance(rtn_callback, CallbackQuitEvent):
-                return rtn_callback, int((get_time() - start) * 1000)
+            if isinstance(function, FunctionType):
+                function()
+            if _internals.active_exp is not None and \
+               _internals.active_exp.is_initialized:
+                rtn_callback = _internals.active_exp._execute_wait_callback()
+                if isinstance(rtn_callback, CallbackQuitEvent):
+                    return rtn_callback, int((get_time() - start) * 1000)
+                if process_control_events:
+                    if _internals.active_exp.mouse.process_quit_event() or \
+                       _internals.active_exp.keyboard.process_control_keys():
+                        break
+                else:
+                    import pygame
+                    pygame.event.pump()
             read = self.interface.poll()
             if read is not None:
                 if code is None: #return for every event
@@ -118,8 +140,11 @@ class TriggerInput(Input):
         until a certain bit pattern is set.
 
         Parameters
-        code -- a specific code to get (int) (optional)
-        bitwise_comparison -- make a bitwise comparison (default=False)
+        ----------
+        code : int, optional
+            a specific code to get
+        bitwise_comparison : bool, optional
+            make a bitwise comparison (default = False)
 
         """
 
@@ -150,8 +175,11 @@ class TriggerInput(Input):
         until a certain bit pattern is set.
 
         Parameters
-        code -- a specific code to count (int) (optional)
-        bitwise_comparison -- make a bitwise comparison (default=False)
+        ----------
+        code : int, optional
+            a specific code to count
+        bitwise_comparison : bool, optional
+            make a bitwise comparison (default = False)
 
         """
 

--- a/expyriment/io/_triggerinput.py
+++ b/expyriment/io/_triggerinput.py
@@ -17,7 +17,7 @@ __date__ = ''
 from . import defaults
 from .. import _internals
 from ..misc import compare_codes
-from .._internals import CallbackQuitEvent
+from .._internals import CallbackQuitEvent, skip_wait_functions
 from ..misc._timer import get_time
 from ._keyboard import Keyboard
 from  ._input_output import Input
@@ -77,7 +77,7 @@ class TriggerInput(Input):
 
        """
 
-        if defaults._skip_wait_functions:
+        if skip_wait_functions:
             return None, None
         start = get_time()
         found = None

--- a/expyriment/io/defaults.py
+++ b/expyriment/io/defaults.py
@@ -92,5 +92,3 @@ textmenu_select_frame_colour = _constants.C_EXPYRIMENT_ORANGE
 textmenu_select_frame_line_width = 0
 textmenu_justification = 1
 textmenu_scroll_menu = 0
-
-_skip_wait_functions = False

--- a/expyriment/misc/_clock.py
+++ b/expyriment/misc/_clock.py
@@ -12,11 +12,14 @@ __version__ = ''
 __revision__ = ''
 __date__ = ''
 
+
 import sys
 import time
 from types import FunctionType
+
 from ._timer import get_time
 from .. import _internals
+
 
 class Clock(object) :
     """Basic timing class.
@@ -110,8 +113,8 @@ class Clock(object) :
         function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
-            process ``Keyboard.process_control_keys()`` and
-            ``Mouse.process_quit_event()`` (default=False)
+            process ``io.Keyboard.process_control_keys()`` and
+            ``io.Mouse.process_quit_event()`` (default = False)
 
         Returns
         -------
@@ -127,36 +130,44 @@ class Clock(object) :
         if _internals.skip_wait_functions:
             return
         start = self.time
-        if isinstance(function, FunctionType) or\
-           _internals.active_exp.is_callback_registered:
+        if isinstance(function, FunctionType) or \
+           (_internals.active_exp is not None and \
+            (process_control_events or \
+             _internals.active_exp.is_callback_registered)):
             while (self.time < start + waiting_time):
                 if isinstance(function, FunctionType):
                     function()
-                rtn_callback = _internals.active_exp._execute_wait_callback()
-                if isinstance(rtn_callback, _internals.CallbackQuitEvent):
-                    return rtn_callback
                 if _internals.active_exp.is_initialized:
-                    import pygame
-                    pygame.event.pump()
+                    rtn_callback = _internals.active_exp._execute_wait_callback()
+                    if isinstance(rtn_callback, _internals.CallbackQuitEvent):
+                        return rtn_callback
                     if process_control_events:
-                        _internals.active_exp.keyboard.process_control_keys()
+                        if _internals.active_exp.keyboard.process_control_keys():
+                            break
                         _internals.active_exp.mouse.process_quit_event()
+                    else:
+                        import pygame
+                        pygame.event.pump()
         else:
             looptime = 200
             if (waiting_time > looptime):
-                if _internals.active_exp.is_initialized:
+                if _internals.active_exp is not None and \
+                   _internals.active_exp.is_initialized:
                     while (self.time < start + (waiting_time - looptime)):
-                        import pygame
-                        pygame.event.pump()
                         if process_control_events:
-                            _internals.active_exp.keyboard.process_control_keys()
-                            _internals.active_exp.mouse.process_quit_event()
+                            if _internals.active_exp.mouse.process_quit_event() or \
+                               _internals.active_exp.keyboard.process_control_keys():
+                                break
+                        else:
+                            import pygame
+                            pygame.event.pump()
                 else:
                     time.sleep((waiting_time - looptime) // 1000)
             while (self.time < start + waiting_time):
                 pass
 
-    def wait_seconds(self, time_sec, function=None):
+    def wait_seconds(self, time_sec, function=None,
+                     process_control_events=False):
         """Wait for a certain amout of seconds.
 
         Parameters
@@ -165,6 +176,9 @@ class Clock(object) :
             time to wait in seconds
         function : function, optional
             function to repeatedly execute during waiting loop
+        process_control_events : bool, optional
+            process ``io.Keyboard.process_control_keys()`` and
+            ``io.Mouse.process_quit_event()`` (default = False)
 
         Returns
         -------
@@ -177,9 +191,10 @@ class Clock(object) :
 
         """
 
-        return self.wait(time_sec * 1000, function)
+        return self.wait(time_sec * 1000, function, process_control_events)
 
-    def wait_minutes(self, time_minutes, function=None):
+    def wait_minutes(self, time_minutes, function=None,
+                     process_control_events=False):
         """Wait for a certain amount of minutes.
 
         Parameters
@@ -188,6 +203,9 @@ class Clock(object) :
             time to wait in minutes
         function : function, optional
             function to repeatedly execute during waiting loop
+        process_control_events : bool, optional
+            process ``io.Keyboard.process_control_keys()`` and
+            ``io.Mouse.process_quit_event()`` (default = False)
 
         Returns
         -------
@@ -200,4 +218,5 @@ class Clock(object) :
 
         """
 
-        return self.wait_seconds(time_minutes * 60, function)
+        return self.wait_seconds(time_minutes * 60, function,
+                                 process_control_events)

--- a/expyriment/misc/_clock.py
+++ b/expyriment/misc/_clock.py
@@ -103,8 +103,8 @@ class Clock(object) :
 
         self.__start = get_time()
 
-    def wait(self, waiting_time, function=None, process_control_events=False):
-        """Wait for a certain amout of milliseconds.
+    def wait(self, waiting_time, callback_function=None, process_control_events=False):
+        """Wait for a certain amount of milliseconds.
 
         Parameters
         ----------
@@ -130,13 +130,13 @@ class Clock(object) :
         if _internals.skip_wait_functions:
             return
         start = self.time
-        if isinstance(function, FunctionType) or \
+        if isinstance(callback_function, FunctionType) or \
            (_internals.active_exp is not None and \
             (process_control_events or \
              _internals.active_exp.is_callback_registered)):
             while (self.time < start + waiting_time):
-                if isinstance(function, FunctionType):
-                    function()
+                if isinstance(callback_function, FunctionType):
+                    callback_function()
                 if _internals.active_exp.is_initialized:
                     rtn_callback = _internals.active_exp._execute_wait_callback()
                     if isinstance(rtn_callback, _internals.CallbackQuitEvent):
@@ -166,7 +166,7 @@ class Clock(object) :
             while (self.time < start + waiting_time):
                 pass
 
-    def wait_seconds(self, time_sec, function=None,
+    def wait_seconds(self, time_sec, callback_function=None,
                      process_control_events=False):
         """Wait for a certain amout of seconds.
 
@@ -174,7 +174,7 @@ class Clock(object) :
         ----------
         time_sec : int
             time to wait in seconds
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.Keyboard.process_control_keys()`` and
@@ -191,9 +191,9 @@ class Clock(object) :
 
         """
 
-        return self.wait(time_sec * 1000, function, process_control_events)
+        return self.wait(time_sec * 1000, callback_function, process_control_events)
 
-    def wait_minutes(self, time_minutes, function=None,
+    def wait_minutes(self, time_minutes, callback_function=None,
                      process_control_events=False):
         """Wait for a certain amount of minutes.
 
@@ -201,7 +201,7 @@ class Clock(object) :
         ----------
         time_minutes : int
             time to wait in minutes
-        function : function, optional
+        callback_function : function, optional
             function to repeatedly execute during waiting loop
         process_control_events : bool, optional
             process ``io.Keyboard.process_control_keys()`` and
@@ -218,5 +218,5 @@ class Clock(object) :
 
         """
 
-        return self.wait_seconds(time_minutes * 60, function,
+        return self.wait_seconds(time_minutes * 60, callback_function,
                                  process_control_events)


### PR DESCRIPTION
This is an attempt to make the wait methods more similar in usage.

The following has changed:
- `control.set_develop_mode` got parameter `skip_wait_functions` which toggles `_internal.skip_wait_functions`
- all wait methods in `io` got the parameter `process_control_events` (replacing the old `process_control_keys`, which check for both `io.Keyboard.process_control_keys` and `io.Mouse.process_quit_event`. `process_control_events` defaults to `True`.
- all wait methods in `io` got the parameter `function` (like `misc.Clock.wait` has)
- `misc.Clock.wait` got the parameter `process_control_events`, which does the same as above. Here it defaults to `False`, however.
- all wait methods pump the Pygame even queue if neccessary

**Please thoroughly review and test before merging, as the changes are in timing-critical parts!**