### PR TITLE
Wait method improvements.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,7 +32,7 @@ Changed:
         specific function in every loop iteration
     (3) pump the pygame event queue to (hopefully) prevent the OS to think the
         window is "not responding"
-- control.set_develop_mode: new skip_wait_functions attribute to ommit all wait 
+- control.set_develop_mode: new skip_wait_methods attribute to ommit all wait 
   functions in the experiment (for testing)
 - rename method: stimulus.replace --> stimulus.reposition
 - improvements to io.extras.TcpClient

--- a/expyriment/_internals.py
+++ b/expyriment/_internals.py
@@ -15,6 +15,9 @@ __date__ = ''
 
 import sys
 import os
+
+import pygame
+
 try:
     import android
 except ImportError:
@@ -46,12 +49,12 @@ def get_version():
 
 PYTHON3 = (sys.version_info[0] == 3)
 
-active_exp = None # expyriment.design.__init__ sets active_exp to
-                  # design.Experiment("None")
-                  # Provides the access to the currently active experiment
-                  # import ._internals to read and write _active.exp
+active_exp = None  # expyriment.design.__init__ sets active_exp to
+                   # design.Experiment("None")
+                   # Provides the access to the currently active experiment
+                   # import ._internals to read and write _active.exp
 
-skip_wait_functions = False  # global toggle, can be changed by set_develop_mode
+skip_wait_methods = False  # global toggle, can be changed by set_develop_mode
 
 def is_base_string(s):
     if PYTHON3:
@@ -70,6 +73,9 @@ def is_byte_string(s):
         return isinstance(s, bytes)
     else:
         return isinstance(s, str)
+
+def pump_pygame_events():
+    pygame.event.pump()
 
 class Expyriment_object(object):
     """A class implementing a general Expyriment object.

--- a/expyriment/io/_gamepad.py
+++ b/expyriment/io/_gamepad.py
@@ -23,7 +23,9 @@ from ..misc._timer import get_time
 from ._keyboard import Keyboard
 from  ._input_output import Input, Output
 
+
 pygame.joystick.init()
+
 
 class GamePad(Input, Output):
     """A class for creating gamepad/joystick input."""
@@ -232,13 +234,19 @@ class GamePad(Input, Output):
         rt : int
             reaction time in ms
 
+        Notes
+        ------
+        This will also by default process control events (quit and pause).
+        Thus, keyboard events will be cleared from the cue and cannot be
+        received by a Keyboard().check() anymore!
+
         See Also
         --------
         design.experiment.register_wait_callback_function
 
         """
 
-        if _internals.skip_wait_functions:
+        if _internals.skip_wait_methods:
             return None, None
         start = get_time()
         rt = None

--- a/expyriment/io/_keyboard.py
+++ b/expyriment/io/_keyboard.py
@@ -249,7 +249,7 @@ class Keyboard(Input):
 
         """
 
-        if _internals.skip_wait_functions:
+        if _internals.skip_wait_methods:
             return None, None
         if android_show_keyboard is not None:
             android_show_keyboard()
@@ -341,7 +341,7 @@ class Keyboard(Input):
 
         """
 
-        if _internals.skip_wait_functions:
+        if _internals.skip_wait_methods:
             return None, None
         start = get_time()
         rt = None

--- a/expyriment/io/_mouse.py
+++ b/expyriment/io/_mouse.py
@@ -407,7 +407,14 @@ class Mouse(Input):
     def wait_event(self, wait_button=True, wait_motion=True, buttons=None,
                    duration=None, wait_for_buttonup=False,
                    callback_function=None, process_control_events=True):
-        """Wait for a mouse event (i.e., motion, button press or wheel event)
+        """Wait for a mouse event (i.e., motion, button press or wheel event).
+
+        Button id coding:
+
+        - None    for no mouse button event or
+        - 0,1,2   for left. middle and right button or
+        - 3       for wheel up or
+        - 4       for wheel down (wheel works only for keydown events).
 
         Parameters
         ----------
@@ -440,12 +447,9 @@ class Mouse(Input):
 
         Notes
         ------
-        button id coding
-
-        - None    for no mouse button event or
-        - 0,1,2   for left. middle and right button or
-        - 3       for wheel up or
-        - 4       for wheel down (wheel works only for keydown events).
+        This will also by default process control events (quit and pause).
+        Thus, keyboard events will be cleared from the cue and cannot be
+        received by a Keyboard().check() anymore!
 
         See Also
         --------
@@ -453,7 +457,7 @@ class Mouse(Input):
 
         """
 
-        if _internals.skip_wait_functions:
+        if _internals.skip_wait_methods:
             return None, None, None, None
         start = get_time()
         self.clear()

--- a/expyriment/io/_streamingbuttonbox.py
+++ b/expyriment/io/_streamingbuttonbox.py
@@ -19,7 +19,7 @@ from types import FunctionType
 from . import defaults
 from .. import _internals
 from ..misc import compare_codes
-from .._internals import CallbackQuitEvent, skip_wait_functions
+from .._internals import CallbackQuitEvent, skip_wait_methods
 from ..misc._timer import get_time
 from ._input_output import Input, Output
 
@@ -117,15 +117,9 @@ class StreamingButtonBox(Input, Output):
              process_control_events=True):
         """Wait for responses defined as codes.
 
-        Notes
-        -----
         If bitwise_comparison = True, the function performs a bitwise
         comparison (logical and) between codes and received input and waits
         until a certain bit pattern is set.
-
-        This will also by default check for control keys (quit and pause).
-        Thus, keyboard events will be cleared from the cue and cannot be
-        received by a Keyboard().check() anymore!
 
         Parameters
         ----------
@@ -152,13 +146,19 @@ class StreamingButtonBox(Input, Output):
         rt : int
             reaction time
 
+        Notes
+        -----
+        This will also by default process control events (quit and pause).
+        Thus, keyboard events will be cleared from the cue and cannot be
+        received by a Keyboard().check() anymore!
+
         See Also
         --------
         design.experiment.register_wait_callback_function
 
         """
 
-        if _internals.skip_wait_functions:
+        if _internals.skip_wait_methods:
             return None, None
         start = get_time()
         rt = None
@@ -179,8 +179,7 @@ class StreamingButtonBox(Input, Output):
                        _internals.active_exp.keyboard.process_control_keys():
                         break
                 else:
-                    import pygame
-                    pygame.event.pump()
+                    _internals.pump_pygame_events()
             if duration is not None:
                 if int((get_time() - start) * 1000) > duration:
                     return None, None

--- a/expyriment/io/_touchscreenbuttonbox.py
+++ b/expyriment/io/_touchscreenbuttonbox.py
@@ -248,6 +248,10 @@ class TouchScreenButtonBox(Input):
 
         Notes
         -----
+        This will also by default process control events (quit and pause).
+        Thus, keyboard events will be cleared from the cue and cannot be
+        received by a Keyboard().check() anymore!
+
         Don't forget to show the TouchScreenButtonBox.
 
         See Also
@@ -256,7 +260,7 @@ class TouchScreenButtonBox(Input):
 
         """
 
-        if _internals.skip_wait_functions:
+        if _internals.skip_wait_methods:
             return None, None
         start = get_time()
         self.clear_event_buffer()
@@ -274,8 +278,7 @@ class TouchScreenButtonBox(Input):
                         pressed_button_field, rt = None, None
                         break
                 else:
-                    import pygame
-                    pygame.event.pump()
+                    _internals.pump_pygame_events()
             pressed_button_field, touch_time = self.check(button_fields)
             if pressed_button_field is not None:
                 rt = int((get_time()-start)*1000)

--- a/expyriment/io/_triggerinput.py
+++ b/expyriment/io/_triggerinput.py
@@ -82,13 +82,19 @@ class TriggerInput(Input):
             process ``io.Keyboard.process_control_keys()`` and
             ``io.Mouse.process_quit_event()`` (default = True)
 
+        Notes
+        -----
+        This will also by default process control events (quit and pause).
+        Thus, keyboard events will be cleared from the cue and cannot be
+        received by a Keyboard().check() anymore!
+
         See Also
         --------
         design.experiment.register_wait_callback_function
 
        """
 
-        if _internals.skip_wait_functions:
+        if _internals.skip_wait_methods:
             return None, None
         start = get_time()
         found = None
@@ -109,8 +115,7 @@ class TriggerInput(Input):
                        _internals.active_exp.keyboard.process_control_keys():
                         break
                 else:
-                    import pygame
-                    pygame.event.pump()
+                    _internals.pump_pygame_events()
             read = self.interface.poll()
             if read is not None:
                 if code is None: #return for every event

--- a/expyriment/io/extras/_tcpserver.py
+++ b/expyriment/io/extras/_tcpserver.py
@@ -15,13 +15,14 @@ __date__ = ''
 
 import socket
 import errno
+from types import FunctionType
+
 from ... import _internals
 from ...misc._timer import get_time
 from ..._internals import CallbackQuitEvent
 from ...io._keyboard import Keyboard
 from ...io._input_output import Input, Output
 from . import _tcpserver_defaults as defaults
-from ..defaults import _skip_wait_functions
 
 
 
@@ -131,11 +132,11 @@ class TcpServer(Input, Output):
                     "TcpServer,sent,{0}".format(data))
 
     def wait(self, length, package_size=None, duration=None,
-             check_control_keys=True):
+             callback_function=None, process_control_events=True):
         """Wait for data.
 
-        Parameters:
-        -----------
+        Parameters
+        ----------
         length : int
             The length of the data to be waited for in bytes.
             If not set, a single package will be waited for.
@@ -145,18 +146,28 @@ class TcpServer(Input, Output):
             If length < package_size, package_size = length.
         duration: int, optional
             The duration to wait in milliseconds.
-        process_control_keys : bool, optional
-            Check if control key has been pressed (default = True).
+        callback_function : function, optional
+            function to repeatedly execute during waiting loop
+        process_control_events : bool, optional
+            process ``io.Keyboard.process_control_keys()`` and
+            ``io.Mouse.process_quit_event()`` (default = True)
 
-        Returns:
-        --------
+        Returns
+        -------
         data : str
             The received data.
         rt : int
             The time it took to receive the data in milliseconds.
+
+        Notes
+        -----
+        This will also by default process control events (quit and pause).
+        Thus, keyboard events will be cleared from the cue and cannot be
+        received by a Keyboard().check() anymore!
+
         """
 
-        if _skip_wait_functions:
+        if _internals.skip_wait_methods:
             return None, None
 
         start = get_time()
@@ -188,13 +199,22 @@ class TcpServer(Input, Output):
             except socket.error as e:
                 err = e.args[0]
                 if err == errno.EAGAIN or err == errno.EWOULDBLOCK:
-                    rtn_callback = _internals.active_exp._execute_wait_callback()
-                    if isinstance(rtn_callback, CallbackQuitEvent):
-                        return rtn_callback, int((get_time() - start) * 1000)
-
-                    if check_control_keys:
-                        if Keyboard.process_control_keys():
+                    if isinstance(callback_function, FunctionType):
+                        callback_function()
+                    if _internals.active_exp is not None and \
+                    _internals.active_exp.is_initialized:
+                        rtn_callback = _internals.active_exp._execute_wait_callback()
+                        if isinstance(rtn_callback, CallbackQuitEvent):
+                            data = rtn_callback
+                            rt = int((get_time() - start) * 1000)
                             break
+                        if process_control_events:
+                            if _internals.active_exp.mouse.process_quit_event() or \
+                            _internals.active_exp.keyboard.process_control_keys():
+                                break
+                        else:
+                            _internals.pump_pygame_events()
+
             if duration:
                 if int((get_time() - start) * 1000) >= duration:
                     data = None

--- a/expyriment/misc/_clock.py
+++ b/expyriment/misc/_clock.py
@@ -127,7 +127,7 @@ class Clock(object) :
 
         """
 
-        if _internals.skip_wait_functions:
+        if _internals.skip_wait_methods:
             return
         start = self.time
         if isinstance(callback_function, FunctionType) or \
@@ -146,8 +146,7 @@ class Clock(object) :
                             break
                         _internals.active_exp.mouse.process_quit_event()
                     else:
-                        import pygame
-                        pygame.event.pump()
+                        _internals.pump_pygame_events()
         else:
             looptime = 200
             if (waiting_time > looptime):


### PR DESCRIPTION
Some more additions to the wait methods:

1. `skip_wait_functions` renamed to `skip_wait_methods`
2. Previous additions added to:
    - `io.extras.CedrusResponseDevice.wait`
    -  `control.wait_end_audiosystem`
    - `stimuli.Video.wait_frame`
    - `stimuli.Video.wait_end`
    - `io.SerialPort.read_line`
3. Added `_internals.pump_pygame_events`

**Please review before merging.**

Also, I was wondering if the local `callback_function` should not also return a potential `CallbackQuitEvent`?