### PR TITLE
Local callback_function fixes.

### DIFF
--- a/expyriment/control/_miscellaneous.py
+++ b/expyriment/control/_miscellaneous.py
@@ -97,7 +97,13 @@ def wait_end_audiosystem(channel=None, callback_function=None,
         if _internals.skip_wait_methods:
             break
         if isinstance(callback_function, FunctionType):
-            callback_function
+            rtn_callback = callback_function()
+            if isinstance(rtn_callback, CallbackQuitEvent):
+                if channel is None:
+                    pygame.mixer.stop()
+                else:
+                    channel.stop()
+                return rtn_callback
         if _internals.active_exp is not None and \
            _internals.active_exp.is_initialized:
             rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_gamepad.py
+++ b/expyriment/io/_gamepad.py
@@ -261,7 +261,11 @@ class GamePad(Input, Output):
         done = False
         while not done:
             if isinstance(callback_function, FunctionType):
-                callback_function()
+                rtn_callback = callback_function()
+                if isinstance(rtn_callback, _internals.CallbackQuitEvent):
+                    _button = rtn_callback
+                    rt = int((get_time() - start) * 1000)
+                    done = True
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_keyboard.py
+++ b/expyriment/io/_keyboard.py
@@ -272,7 +272,11 @@ class Keyboard(Input):
         done = False
         while not done:
             if isinstance(callback_function, FunctionType):
-                callback_function
+                rtn_callback = callback_function()
+                if isinstance(rtn_callback, _internals.CallbackQuitEvent):
+                    done = True
+                    found_key = rtn_callback
+                    rt = int((get_time() - start) * 1000)
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()
@@ -356,14 +360,18 @@ class Keyboard(Input):
 
         while not done:
             if isinstance(callback_function, FunctionType):
-                callback_function()
+                rtn_callback = callback_function()
+                if isinstance(rtn_callback, _internals.CallbackQuitEvent):
+                    done = True
+                    rt = int((get_time() - start) * 1000)
+                    found_char = rtn_callback
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()
                 if isinstance(rtn_callback, _internals.CallbackQuitEvent):
-                        done = True
-                        rt = int((get_time() - start) * 1000)
-                        found_char = rtn_callback
+                    done = True
+                    rt = int((get_time() - start) * 1000)
+                    found_char = rtn_callback
                 if process_control_events:
                     _internals.active_exp.mouse.process_quit_event()
             for event in pygame.event.get([pygame.KEYUP, pygame.KEYDOWN]):

--- a/expyriment/io/_mouse.py
+++ b/expyriment/io/_mouse.py
@@ -474,7 +474,11 @@ class Mouse(Input):
                 buttons = [buttons]
         while True:
             if isinstance(callback_function, FunctionType):
-                callback_function()
+                rtn_callback = callback_function()
+                if isinstance(rtn_callback, _internals.CallbackQuitEvent):
+                    btn_id = rtn_callback
+                    rt = int((get_time() - start) * 1000)
+                    break
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_serialport.py
+++ b/expyriment/io/_serialport.py
@@ -412,7 +412,10 @@ The Python package 'pySerial' is not installed."""
 
         while True:
             if isinstance(callback_function, FunctionType):
-                callback_function()
+                rtn_callback = callback_function()
+                if isinstance(rtn_callback, CallbackQuitEvent):
+                    rtn_string = rtn_callback
+                    break
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_streamingbuttonbox.py
+++ b/expyriment/io/_streamingbuttonbox.py
@@ -166,7 +166,11 @@ class StreamingButtonBox(Input, Output):
             self.clear()
         while True:
             if isinstance(callback_function, FunctionType):
-                callback_function()
+                rtn_callback = callback_function()
+                if isinstance(rtn_callback, CallbackQuitEvent):
+                    found = rtn_callback
+                    rt = int((get_time() - start) * 1000)
+                    break
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/io/_touchscreenbuttonbox.py
+++ b/expyriment/io/_touchscreenbuttonbox.py
@@ -266,7 +266,9 @@ class TouchScreenButtonBox(Input):
         self.clear_event_buffer()
         while True:
             if isinstance(callback_function, FunctionType):
-                callback_function()
+                rtn_callback = callback_function()
+                if isinstance(rtn_callback, CallbackQuitEvent):
+                    return rtn_callback, int((get_time()-start)*1000)
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()

--- a/expyriment/misc/_clock.py
+++ b/expyriment/misc/_clock.py
@@ -136,7 +136,9 @@ class Clock(object) :
              _internals.active_exp.is_callback_registered)):
             while (self.time < start + waiting_time):
                 if isinstance(callback_function, FunctionType):
-                    callback_function()
+                    rtn_callback = callback_function()
+                    if isinstance(rtn_callback, _internals.CallbackQuitEvent):
+                        return rtn_callback
                 if _internals.active_exp.is_initialized:
                     rtn_callback = _internals.active_exp._execute_wait_callback()
                     if isinstance(rtn_callback, _internals.CallbackQuitEvent):

--- a/expyriment/stimuli/_video.py
+++ b/expyriment/stimuli/_video.py
@@ -500,7 +500,9 @@ class Video(_visual.Stimulus):
                 break
 
             if isinstance(callback_function, FunctionType):
-                callback_function()
+                rtn_callback = callback_function()
+                if isinstance(rtn_callback, CallbackQuitEvent):
+                    return rtn_callback
             if _internals.active_exp is not None and \
                _internals.active_exp.is_initialized:
                 rtn_callback = _internals.active_exp._execute_wait_callback()


### PR DESCRIPTION
Added checks for `CallbackQuitEvent` to the local `callback_function`.

One thing we still might to check is that some wait methods (e.g. in Keyboard) will always respond to quit events by setting `done=True`, such that the rest of the loop is still processed, while others (e.g. in Clock) will do a `break`, leading to an instant return. We might want to have consistent behaviour there.