### PR TITLE
Introducing a new bws factor handling

### DIFF
--- a/expyriment/control/_experiment_control.py
+++ b/expyriment/control/_experiment_control.py
@@ -169,13 +169,13 @@ def start(experiment=None, auto_create_subject_id=None, subject_id=None,
         experiment.data.add_experiment_info(line)
 
     for f in experiment.bws_factor_names():
-        _permuted_bws_factor_condition = \
+        _bws_factor_condition = \
             experiment.get_bws_factor_condition(f)
-        if isinstance(_permuted_bws_factor_condition, unicode):
-            _permuted_bws_factor_condition = \
-                unicode2str(_permuted_bws_factor_condition)
+        if isinstance(_bws_factor_condition, unicode):
+            _bws_factor_condition = \
+                unicode2str(_bws_factor_condition)
         experiment.data.add_subject_info("{0} = {1}".format(
-            unicode2str(f), _permuted_bws_factor_condition))
+            unicode2str(f), _bws_factor_condition))
 
     if experiment.events is not None:
         experiment.events._time_stamp = experiment.data._time_stamp

--- a/expyriment/control/_experiment_control.py
+++ b/expyriment/control/_experiment_control.py
@@ -168,9 +168,9 @@ def start(experiment=None, auto_create_subject_id=None, subject_id=None,
     for line in experiment.__str__().splitlines():
         experiment.data.add_experiment_info(line)
 
-    for f in experiment.bws_factor_names:
+    for f in experiment.bws_factor_names():
         _permuted_bws_factor_condition = \
-            experiment.get_permuted_bws_factor_condition(f)
+            experiment.get_bws_factor_condition(f)
         if isinstance(_permuted_bws_factor_condition, unicode):
             _permuted_bws_factor_condition = \
                 unicode2str(_permuted_bws_factor_condition)

--- a/expyriment/design/_structure.py
+++ b/expyriment/design/_structure.py
@@ -208,18 +208,15 @@ class Experiment(object):
 
     def __str__(self):
         tmp_str = "Experiment: {0}\n".format(unicode2str(self.name))
-        if len(self.bws_factor_names) <= 0:
+        if len(self.bws_factor_names()) <= 0:
             tmp_str = tmp_str + "no between subject factors\n"
         else:
-            tmp_str = tmp_str + "between subject factors (permutation type: "
-            if self.bws_factor_randomized:
-                tmp_str = tmp_str + "random)\n"
-            else:
-                tmp_str = tmp_str + "latin square)\n"
-            for f in self.bws_factor_names:
+            tmp_str = tmp_str + "between subject factors"
+            for f in self.bws_factor_names():
                 _bws_factor = \
                     [unicode2str(x) if isinstance(x, unicode) else
                      repr(x) for x in self._bws_factors[f]]
+                _bws_factor = _bws_factor + "(" + self._bws_factor_type + ")"
                 tmp_str = tmp_str + "    {0} = [{1}]\n".format(
                     unicode2str(f), ", ".join(_bws_factor))
         for block in self.blocks:
@@ -295,29 +292,73 @@ class Experiment(object):
         if self.data is not None:
             self.data.add_experiment_info(text)
 
-    @property
-    def bws_factor_randomized(self):
-        """Getter for bws_factor_randomized.
+    def get_bws_factor_type(self, factor_name):
+        """Gets type of a factor.
+
+        Parameters
+        ----------
+        factor_name: str
+            the name of the between subject factor
+
+        Returns
+        -------
+        factor_type : str
+            type of the factor
 
         Notes
         -----
-        Is between subject factor randomized? (True/False).
+        This functions returns the type of a factor. Type means whether a
+        factor is cross-balanced between all other cross-balanced factors
+        (latin-square), just balanced over itself or fully randomized. Return
+        values may be "balanced" (latin-square), "unbalanced" or "random".
 
-        If True conditions will be assigned randomized
-        otherwise (default) conditions will be systematically permuted across
-        subjects.
+        See Also
+        --------
+        set_bws_factor_type
 
         """
 
-        return self._bws_factor_randomized
+        return self._bws_factor_type[factor_name]
 
-    @bws_factor_randomized.setter
-    def bws_factor_randomized(self, value):
-        """Setter for bws_factor_randomized."""
+    def set_bws_factor_type(self, factor_name, factor_type):
+        """Sets type of a factor.
 
-        self._bws_factor_randomized = value
+        Parameters
+        ----------
+        factor_name: str
+            the name of the between subject factor
+        factor_type: str
+            desired type of the factor. Either "balanced", "unbalanced" or
+            "random"
 
-    def add_bws_factor(self, factor_name, conditions):
+        Returns
+        -------
+        factor_type : str
+            type of the factor
+
+        Notes
+        -----
+        This functions sets the type of a factor. Type means whether a
+        factor is cross-balanced between all other cross-balanced factors
+        (latin-square), just balanced over itself or fully randomized. Return
+        values may be "balanced" (latin-square), "unbalanced" or "random".
+
+        See Also
+        --------
+        set_bws_factor_type
+
+        """
+
+        if not factor_name in self._bws_factors:
+            raise ValueError("Factor not known.")
+
+        if factor_type in ["random", "balanced", "unbalanced"]:
+            self._bws_factors_type[factor_name] = factor_type
+        else:
+            raise ValueError("Factor type has to be one" + 
+                    "of \"random\", \"balanced\" or \"unbalanced\".")
+
+    def add_bws_factor(self, factor_name, conditions, factor_type="balanced"):
         """Add a between subject factor.
 
         Parameters
@@ -326,17 +367,25 @@ class Experiment(object):
             the name of the between subject factor
         conditions : list
             possible conditions of the between subject factor
+        factor_type : str
+            type of the factor (default: "balanced")
 
         Notes
         -----
-        The defined between subject factor conditions will be permuted across
-        the subjects when 'using get_permuted_bws_factor_condition'.
-        Factors that are added first are treated as hierarchically higher
-        factors while permutation.
+        This functions adds a new between subject factor with the given
+        conditions to the experiment. Type of a factor determines
+        how a factor is randomized between subjects. Type "balanced" means
+        that factor conditions will be permuted across all other balanced
+        factors (latin-square). Factors that are added first are treated as
+        hierarchically higher factors while permutation.
+        Type "unbalanced" means that factor conditions will be permuted
+        regardless of other factors.
+        A "random" factor will be fully randomized and not permuted. See
+        get_bws_factor_condition for getting a factor condition.
 
         See Also
         --------
-        get_permuted_bws_factor_condition
+        get_bws_factor_condition
 
         """
 
@@ -344,6 +393,13 @@ class Experiment(object):
             conditions = list(conditions)
         except:
             conditions = [conditions]
+
+        if factor_type in ["random", "balanced", "unbalanced"]:
+            self._bws_factors_type[factor_name] = factor_type
+        else:
+            raise ValueError("Factor type has to be one" + 
+                    "of \"random\", \"balanced\" or \"unbalanced\".")
+
         self._bws_factors[factor_name] = conditions
         self._bws_factors_names.append(factor_name)
         self._randomized_condition_for_subject[factor_name] = {}
@@ -352,18 +408,12 @@ class Experiment(object):
         """Return all conditions of this between subject factor."""
 
         try:
-            cond = self._bws_factors[factor_name]
+            return self._bws_factors[factor_name]
         except:
             return None
-        return cond
 
-    def get_permuted_bws_factor_condition(self, factor_name, subject_id=None):
+    def get_bws_factor_condition(self, factor_name, subject_id=None):
         """Get the between subject factor condition for a subject.
-
-        The condition for the current subject will be returned, if expyriment
-        is running and the function is called without a subject_id.
-        If the function is called with a subject_id, the condition for this
-        particular subject will be returned.
 
         Parameters
         ----------
@@ -378,7 +428,17 @@ class Experiment(object):
 
         Notes
         -----
-        see add_bws_factor
+        The condition for the current subject will be returned, if expyriment
+        is running and the function is called without a subject_id.
+        If the function is called with a subject_id, the condition for this
+        particular subject will be returned.
+
+        The return factor condition depends on factor type. See add_bws_factor
+        for more information on that.
+
+        See Also
+        --------
+        add_bws_factor
 
         """
 
@@ -392,7 +452,7 @@ class Experiment(object):
                 subject_id = self.subject
 
         cond_idx = 0
-        if self.bws_factor_randomized:
+        if self._bws_factors_type[factor_name] == "random":
             try:
                 cond_idx = self._randomized_condition_for_subject[
                     factor_name][subject_id]
@@ -401,19 +461,20 @@ class Experiment(object):
                     0, len(self._bws_factors[factor_name]) - 1)
                 self._randomized_condition_for_subject[
                     factor_name][subject_id] = cond_idx
-
-        else:  # Permutation
-            # (n_cond_lower_fac) total number of conditions for all
+        elif self._bws_factors_type[factor_name] == "balanced":
+            # (n_cond_lower) total number of conditions for all
             # hierarchically lower factors
-            n_cond_lower_fac = self.n_bws_factor_conditions
-            for fac in self.bws_factor_names:
-                n_cond_lower_fac -= len(self.get_bws_factor(fac))
+            n_cond_lower = self.n_bws_factor_conditions(factor_type="balanced")
+            for fac in self.bws_factor_names(factor_type="balanced"):
+                n_cond_lower -= len(self.get_bws_factor(fac))
                 if fac is factor_name:
                     break
-            if n_cond_lower_fac <= 0:
-                n_cond_lower_fac = 1
-            cond_idx = ((subject_id - 1) / n_cond_lower_fac) % \
+            if n_cond_lower <= 0:
+                n_cond_lower = 1
+            cond_idx = ((subject_id - 1) / n_cond_lower) % \
                 len(self.get_bws_factor(fac))
+        elif self._bws_factors_type[factor_name] == "unbalanced":
+            cond_idx = (subject_id - 1) % len(self.get_bws_factor(factor_name))
 
         return self._bws_factors[factor_name][cond_idx]
 
@@ -425,24 +486,64 @@ class Experiment(object):
         # Can't use dict_keys, because dicts don't keep the order
         self._bws_factors_names = []
 
+        self._bws_factors_type = {}
+
         self._randomized_condition_for_subject = {}
-        self.bws_factor_randomized = False
 
-    @property
-    def bws_factor_names(self):
-        """Getter for factors keys."""
-        return self._bws_factors_names
+    def bws_factor_names(self, factor_type=None):
+        """Returns names of between subject factors
 
-    @property
-    def n_bws_factor_conditions(self):
-        """Getter for n_bws_factor_conditions.
+        Parameters
+        ----------
+        factor_type : str, optional
+            (default=None)
 
-        Total number of conditions in all bws_factors.
+        Returns
+        -------
+        names : list
+            list of names (str)
+
+        Notes
+        -----
+        This function returns the names of between subject factors. If
+        factor_type is not given all factor names are returned. If a specific
+        factor_type is given only factor names with this type are returned.
+
+        """
+
+        if factor_type is None:
+            return self._bws_factors_names
+
+        names = []
+        for i in self._bws_factors_names:
+            if factor_type == self._bws_factors_type[i]:
+                names.append(i)
+
+        return names
+
+    def n_bws_factor_conditions(self, factor_type=None):
+        """Returns the number of all factors
+
+        Parameters
+        ----------
+        factor_type : str, optional
+            (default=None)
+
+        Returns
+        -------
+        n : int
+            number of all factor conditions
+
+        Notes
+        -----
+        This function returns the sum of all between subject factor conditions. If
+        factor_type is not given all factors are considered. If a specific
+        factor_type is given only factors of this type are considered.
 
         """
 
         n = 0
-        for fn in self.bws_factor_names:
+        for fn in self.bws_factor_names(factor_type):
             n += len(self.get_bws_factor(fn))
         return n
 
@@ -732,13 +833,12 @@ type".format(permutation_type))
         if len(self.experiment_info) > 0:
             for txt in self.experiment_info:
                 rtn += u"#xpi: {0}\n".format(txt)
-        if len(self.bws_factor_names) > 0:
-            for factor_name in self.bws_factor_names:
+        if len(self.bws_factor_names()) > 0:
+            for factor_name in self.bws_factor_names():
                 rtn += u"#bws: {0}=".format(factor_name)
                 for txt in self.get_bws_factor(factor_name):
                     rtn += u"{0},".format(txt)
                 rtn = rtn[:-1] + "\n"  # delete last comma
-            rtn += u"#bws-rand: {0}\n".format(int(self.bws_factor_randomized))
         if len(self.data_variable_names) > 0:
             rtn += "#dvn: "
             for txt in self.data_variable_names:
@@ -840,8 +940,6 @@ type".format(permutation_type))
                     elif ln.startswith("#dvn:"):
                         for tmp in ln[6:].split(","):
                             self.add_data_variable_names(tmp.strip())
-                    elif ln.startswith("#bws-rand:"):
-                        self.bws_factor_randomized = (ln[11] == "1")
                     elif ln.startswith("#bws:"):
                         tmp = ln[6:].split("=")
                         print tmp[1].strip().split(",")

--- a/expyriment/design/_structure.py
+++ b/expyriment/design/_structure.py
@@ -382,41 +382,40 @@ class Experiment(object):
 
         """
 
+        if self.get_bws_factor(factor_name) is None:
+            return None  # Factor not defined
+
         if subject_id is None:
             if self.subject is None:  # No current subject id defined
                 return None
             else:  # Use current subject
-                return self.get_permuted_bws_factor_condition(
-                    factor_name, subject_id=self.subject)
-        else:
-            conditions = self.get_bws_factor(factor_name)
-            if conditions is None:
-                return None  # Factor not defined
-            else:
-                cond_idx = 0
-                if self.bws_factor_randomized:
-                    try:
-                        cond_idx = self._randomized_condition_for_subject[
-                            factor_name][subject_id]
-                    except:  # If not yet randomized for this subject, do it
-                        cond_idx = randomize.rand_int(
-                            0, len(self._bws_factors[factor_name]) - 1)
-                        self._randomized_condition_for_subject[
-                            factor_name][subject_id] = cond_idx
+                subject_id = self.subject
 
-                else:  # Permutation
-                    # (n_cond_lower_fac) total number of conditions for all
-                    # hierarchically lower factors
-                    n_cond_lower_fac = self.n_bws_factor_conditions
-                    for fac in self.bws_factor_names:
-                        n_cond_lower_fac -= len(self.get_bws_factor(fac))
-                        if fac is factor_name:
-                            break
-                    if n_cond_lower_fac <= 0:
-                        n_cond_lower_fac = 1
-                    cond_idx = ((subject_id - 1) / n_cond_lower_fac) % \
-                        len(self.get_bws_factor(fac))
-                return self._bws_factors[factor_name][cond_idx]
+        cond_idx = 0
+        if self.bws_factor_randomized:
+            try:
+                cond_idx = self._randomized_condition_for_subject[
+                    factor_name][subject_id]
+            except:  # If not yet randomized for this subject, do it
+                cond_idx = randomize.rand_int(
+                    0, len(self._bws_factors[factor_name]) - 1)
+                self._randomized_condition_for_subject[
+                    factor_name][subject_id] = cond_idx
+
+        else:  # Permutation
+            # (n_cond_lower_fac) total number of conditions for all
+            # hierarchically lower factors
+            n_cond_lower_fac = self.n_bws_factor_conditions
+            for fac in self.bws_factor_names:
+                n_cond_lower_fac -= len(self.get_bws_factor(fac))
+                if fac is factor_name:
+                    break
+            if n_cond_lower_fac <= 0:
+                n_cond_lower_fac = 1
+            cond_idx = ((subject_id - 1) / n_cond_lower_fac) % \
+                len(self.get_bws_factor(fac))
+
+        return self._bws_factors[factor_name][cond_idx]
 
     def clear_bws_factors(self):
         """Remove all between subject factors from design."""

--- a/expyriment/design/_structure.py
+++ b/expyriment/design/_structure.py
@@ -293,7 +293,7 @@ class Experiment(object):
             self.data.add_experiment_info(text)
 
     def get_bws_factor_type(self, factor_name):
-        """Gets type of a factor.
+        """Gets type of a bws factor.
 
         Parameters
         ----------
@@ -321,7 +321,7 @@ class Experiment(object):
         return self._bws_factor_type[factor_name]
 
     def set_bws_factor_type(self, factor_name, factor_type):
-        """Sets type of a factor.
+        """Sets type of a bws factor.
 
         Parameters
         ----------
@@ -331,21 +331,15 @@ class Experiment(object):
             desired type of the factor. Either "balanced", "unbalanced" or
             "random"
 
-        Returns
-        -------
-        factor_type : str
-            type of the factor
-
         Notes
         -----
         This functions sets the type of a factor. Type means whether a
         factor is cross-balanced between all other cross-balanced factors
-        (latin-square), just balanced over itself or fully randomized. Return
-        values may be "balanced" (latin-square), "unbalanced" or "random".
+        (latin-square), just balanced over itself or fully randomized. 
 
         See Also
         --------
-        set_bws_factor_type
+        get_bws_factor_type
 
         """
 
@@ -423,7 +417,7 @@ class Experiment(object):
 
         Returns
         -------
-        cond : str
+        cond : list item
             condition for the current subject
 
         Notes
@@ -433,8 +427,8 @@ class Experiment(object):
         If the function is called with a subject_id, the condition for this
         particular subject will be returned.
 
-        The return factor condition depends on factor type. See add_bws_factor
-        for more information on that.
+        The returned factor condition depends on factor type. See
+        add_bws_factor for more information on that.
 
         See Also
         --------

--- a/expyriment/design/_structure.py
+++ b/expyriment/design/_structure.py
@@ -216,9 +216,10 @@ class Experiment(object):
                 _bws_factor = \
                     [unicode2str(x) if isinstance(x, unicode) else
                      repr(x) for x in self._bws_factors[f]]
-                _bws_factor = _bws_factor + "(" + self._bws_factor_type + ")"
-                tmp_str = tmp_str + "    {0} = [{1}]\n".format(
-                    unicode2str(f), ", ".join(_bws_factor))
+                tmp_str = tmp_str + "    {0} ({1}) = [{2}]\n".format(
+                    unicode2str(f), 
+                    unicode2str(self._bws_factors_type[f]), 
+                    ", ".join(_bws_factor))
         for block in self.blocks:
             tmp_str = tmp_str + "{0}\n".format(unicode2str(block.summary))
         return tmp_str
@@ -318,7 +319,7 @@ class Experiment(object):
 
         """
 
-        return self._bws_factor_type[factor_name]
+        return self._bws_factors_type[factor_name]
 
     def set_bws_factor_type(self, factor_name, factor_type):
         """Sets type of a bws factor.
@@ -458,15 +459,14 @@ class Experiment(object):
         elif self._bws_factors_type[factor_name] == "balanced":
             # (n_cond_lower) total number of conditions for all
             # hierarchically lower factors
-            n_cond_lower = self.n_bws_factor_conditions(factor_type="balanced")
-            for fac in self.bws_factor_names(factor_type="balanced"):
-                n_cond_lower -= len(self.get_bws_factor(fac))
-                if fac is factor_name:
-                    break
+            mylist = self.bws_factor_names(factor_type="balanced")
+            n_cond_lower = 0
+            for f in mylist[(mylist.index(factor_name)+1):len(mylist)]:
+                n_cond_lower += len(self.get_bws_factor(f))
             if n_cond_lower <= 0:
                 n_cond_lower = 1
             cond_idx = ((subject_id - 1) / n_cond_lower) % \
-                len(self.get_bws_factor(fac))
+                len(self.get_bws_factor(factor_name))
         elif self._bws_factors_type[factor_name] == "unbalanced":
             cond_idx = (subject_id - 1) % len(self.get_bws_factor(factor_name))
 
@@ -514,32 +514,6 @@ class Experiment(object):
                 names.append(i)
 
         return names
-
-    def n_bws_factor_conditions(self, factor_type=None):
-        """Returns the number of all factors
-
-        Parameters
-        ----------
-        factor_type : str, optional
-            (default=None)
-
-        Returns
-        -------
-        n : int
-            number of all factor conditions
-
-        Notes
-        -----
-        This function returns the sum of all between subject factor conditions. If
-        factor_type is not given all factors are considered. If a specific
-        factor_type is given only factors of this type are considered.
-
-        """
-
-        n = 0
-        for fn in self.bws_factor_names(factor_type):
-            n += len(self.get_bws_factor(fn))
-        return n
 
     def set_log_level(self, loglevel):
         """Set the log level of the current experiment


### PR DESCRIPTION
Hello,

this pull request changes the bws factors. Now, it's not a global state anymore whether bws factors are randomized or permuted, instead this can be chosen for each factor independently. Using `bws_factor_add()` you can choose whether you want a fully randomized factor (like the old behavior when choosing this state on a global basis) or permuted. Permutation is possible balanced across other balanced factors or independently only for this factor.

This makes cases like in issue #94 possible.

Drawbacks:
- some function names are changed, so it is not compatible with the last expyriment version. Therefore I would suggest to release together with python3 branch. I think there won't be any problems running this within the python3 branch.

I would be happy to see this piece of code merged. Write me if you suggest some changes!

Greetings