### PR TITLE
Installation from source archives (e.g. GitHub downloads)

### DIFF
--- a/.git_export_subst
+++ b/.git_export_subst
@@ -1,0 +1,3 @@
+$Format:%D$
+$Format:%h$
+$Format:%cd$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-.git_export_subst export-subst
+.release_info export-subst

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_export_subst export-subst

--- a/.release_info
+++ b/.release_info
@@ -1,3 +1,3 @@
 $Format:%D$
-$Format:%h$
+$Format:%H$
 $Format:%cd$

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,20 @@ import sys
 from subprocess import Popen, PIPE, call
 try:
     from setuptools import setup
+    from setuptools.command.sdist import sdist
     from setuptools.command.build_py import build_py
     from setuptools.command.install import install
+    from setuptools.command.install_data import install_data
     from setuptools.command.bdist_wininst import bdist_wininst
 except ImportError:
     from distutils.core import setup
+    from distutils.command.sdist import sdist
     from distutils.command.build_py import build_py
     from distutils.command.install import install
+    from distutils.command.install_data import install_data
     from distutils.command.bdist_wininst import bdist_wininst
 from os import remove, close, chmod, path
-from shutil import move, copytree, rmtree
+from shutil import move, copyfile, copytree, rmtree
 from tempfile import mkstemp
 from glob import glob
 
@@ -58,6 +62,12 @@ data_files = [('share/expyriment/documentation/api',
               ('share/expyriment/documentation/sphinx',
                glob('documentation/sphinx/Makefile'))]
 
+source_files = ['.release_info',
+                'CHANGES.MD',
+                'COPYING.txt',
+                'Makefile',
+                'README.md']
+
 install_requires = ["future>=0.15,<1",
                     "pygame>=1.9,<2",
                     "pyopengl>=3.0,<4"]
@@ -74,6 +84,65 @@ extras_require = {
                            "sounddevice>=0.3,<1",
                            "mediadecoder>=0.1,<1"],
     }
+
+
+class Sdist(sdist):
+    def get_file_list(self):
+        version_nr, revision_nr, date = get_version_info_from_release_info()
+        # If code is check out from GitHub repository, change .release_info
+        if date.startswith("$Format:"):
+            version_nr, revision_nr, date = get_version_info_from_git()
+            version_nr = "tag: " + version_nr
+            move(".release_info", ".release_info.bak")
+            with open(".release_info", 'w') as f:
+                f.write(u"{0}\n{1}\n{2}".format(version_nr, revision_nr, date))
+        for f in source_files:
+            self.filelist.append(f)
+        sdist.get_file_list(self)
+
+    def run(self):
+        sdist.run(self)
+        try:
+            move(".release_info.bak", ".release_info")
+        except:
+            pass
+
+
+# Manipulate the header of all files (only for building/installing from
+# repository)
+class Build(build_py):
+    """Specialized Python source builder."""
+
+    def byte_compile(self, files):
+        for f in files:
+            if f.endswith('.py'):
+                # Create temp file
+                fh, abs_path = mkstemp()
+                new_file = open(abs_path, 'wb')
+                old_file = open(f, 'rUb')
+                for line in old_file:
+                    if line[0:11] == '__version__':
+                        new_file.write("__version__ = '" + version_nr + "'" +
+                                       '\n')
+                    elif line[0:12] == '__revision__':
+                        new_file.write("__revision__ = '" + revision_nr + "'"
+                                       + '\n')
+                    elif line[0:8] == '__date__':
+                        new_file.write("__date__ = '" + date + "'" + '\n')
+                    else:
+                        new_file.write(line)
+                # Close temp file
+                new_file.close()
+                close(fh)
+                old_file.close()
+                # Remove original file
+                remove(f)
+                # Move new file
+                move(abs_path, f)
+                chmod(f,
+                      stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
+        build_py.byte_compile(self, files)
+
 
 # Clear old installation when installing
 class Install(install):
@@ -115,194 +184,172 @@ if os.path.isdir(old_installation):
         bdist_wininst.run(self)
 
 
-# Manipulate the header of all files (only for building/installing from
-# repository)
-class Build(build_py):
-    """Specialized Python source builder."""
+# Build Sphinx HTML documentation and add them to data_files
+class InstallData(install_data):
+    def run(self):
+        
+        # Try to build/add documentation
+        try:
+            cwd = os.getcwd()
+            copytree('expyriment', 'documentation/sphinx/expyriment')
+            os.chdir('documentation/sphinx/')
+            call([sys.executable, "./create_rst_api_reference.py"])
+            call(["sphinx-build", "-b", "html", "-d", "_build/doctrees", ".", "_build/html"])
+            os.chdir(cwd)
+            self.data_files.append(('share/expyriment/documentation/html',
+                               glob('documentation/sphinx/_build/html/*.*')))
+            self.data_files.append(('share/expyriment/documentation/html/_downloads',
+                               glob('documentation/sphinx/_build/html/_downloads/*.*')))
+            self.data_files.append(('share/expyriment/documentation/html/_images',
+                               glob('documentation/sphinx/_build/html/_images/*.*')))
+            self.data_files.append(('share/expyriment/documentation/html/_sources',
+                               glob('documentation/sphinx/_build/html/_sources/*.*')))
+            self.data_files.append(('share/expyriment/documentation/html/_static',
+                               glob('documentation/sphinx/_build/html/_static/*.*')))
+            self.data_files.append(('share/expyriment/documentation/html/_static/css',
+                               glob('documentation/sphinx/_build/html/_static/css/*.*')))
+            self.data_files.append(('share/expyriment/documentation/html/_static/fonts',
+                               glob('documentation/sphinx/_build/html/_static/fonts/*.*')))
+            self.data_files.append(('share/expyriment/documentation/html/_static/js',
+                               glob('documentation/sphinx/_build/html/_static/js/*.*')))
+        except:
+            html_created = False
+            warning = "HTML documentation NOT created! (sphinx and numpydoc installed?)"
+            os.chdir(cwd)
 
-    def byte_compile(self, files):
-        for f in files:
-            if f.endswith('.py'):
-                # Create temp file
-                fh, abs_path = mkstemp()
-                new_file = open(abs_path, 'wb')
-                old_file = open(f, 'rUb')
-                for line in old_file:
-                    if line[0:11] == '__version__':
-                        new_file.write("__version__ = '" + version_nr + "'" +
-                                       '\n')
-                    elif line[0:12] == '__revision__':
-                        new_file.write("__revision__ = '" + revision_nr + "'"
-                                       + '\n')
-                    elif line[0:8] == '__date__':
-                        new_file.write("__date__ = '" + date + "'" + '\n')
-                    else:
-                        new_file.write(line)
-                # Close temp file
-                new_file.close()
-                close(fh)
-                old_file.close()
-                # Remove original file
-                remove(f)
-                # Move new file
-                move(abs_path, f)
-                chmod(f,
-                      stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH)
-        build_py.byte_compile(self, files)
+        # Install data
+        install_data.run(self)
+        
+        # Clean up Sphinx folder
+        rmtree("documentation/sphinx/expyriment", ignore_errors=True)
+        rmtree("documentation/sphinx/_build", ignore_errors=True)
+        for file_ in glob("documentation/sphinx/expyriment.*"):
+            remove_file(file_)
+        remove_file("documentation/sphinx/Changelog.rst")
+        remove_file("documentation/sphinx/CommandLineInterface.rst")
+        remove_file("documentation/sphinx/sitemap.yml")
 
-def get_version_from_git():
-    version_nr = "{0}"
-    proc = Popen(['git', 'describe', '--tags', '--dirty', '--always'], \
-                        stdout=PIPE, stderr=PIPE)
 
-    return version_nr.format(proc.stdout.read().lstrip(b"v").strip())
-
-def get_revision_from_git():
-        proc = Popen(['git', 'log', '--format=%H', '-1'], \
-                        stdout=PIPE, stderr=PIPE)
-        return proc.stdout.read().strip()[:7]
-
-def get_date_from_git():
-        proc = Popen(['git', 'log', '--format=%cd', '-1'],
-                     stdout=PIPE, stderr=PIPE)
-        return proc.stdout.readline().strip()
-
-def get_version_from_file(filename):
-    """Get the version (__version__) from a particular file."""
-
-    with open(filename) as f:
-        for line in f:
-            if line.startswith("__version__"):
-                rtn = line.split("'")
-                return rtn[1]
-    return ''
-
-def get_revision_from_file(filename):
-    """Get the revision(__revision__) from a particular file."""
-
-    with open(filename) as f:
-        for line in f:
-            if line.startswith("__revision__"):
-                rtn = line.split("'")
-                return rtn[1]
-    return ''
-
-def get_date_from_file(filename):
-    """Get the date(__date__) from a particular file."""
-
-    with open(filename) as f:
-        for line in f:
-            if line.startswith("__date__"):
-                rtn = line.split("'")
-                return rtn[1]
-    return ''
-
+# Helper functions
 def remove_file(file_):
     try:
         os.remove(file_)
     except:
         pass
 
+def get_version_info_from_git():
+    """Get version number, revision number and date from git repository."""
+
+    proc = Popen(['git', 'describe', '--tags', '--dirty', '--always'], \
+                        stdout=PIPE, stderr=PIPE)
+    version_nr = "{0}".format(proc.stdout.read().lstrip(b"v").strip())
+    proc = Popen(['git', 'log', '--format=%H', '-1'], \
+                        stdout=PIPE, stderr=PIPE)
+    revision_nr = proc.stdout.read().strip()[:7]
+    proc = Popen(['git', 'log', '--format=%cd', '-1'],
+                     stdout=PIPE, stderr=PIPE)
+    date = proc.stdout.readline().strip()
+    return version_nr, revision_nr, date
+
+def get_version_info_from_release_info():
+    """Get version number, revision number and date from .release_info."""
+
+    with open(".release_info") as f:
+        lines = []
+        for line in f:
+            lines.append(line)
+    for x in lines[0].split(","):
+        if "tag:" in x:
+            version_nr = x.replace("tag:","").strip().lstrip(b"v")
+        else:
+            version_nr = ""
+    revision_nr = lines[1].strip()[:7]
+    date = lines[2]
+    # GitHub source archive (snapshot, no tag)
+    if version_nr == "":
+        with open("CHANGES.md") as f:
+            for line in f:
+                if line.lower().startswith("version"):
+                    version_nr = "{0}-0-g{1}".format(line.split(" ")[1],
+                                                    revision_nr)
+                    break
+    return version_nr, revision_nr, date
+
+def get_version_info_from_file(filename):
+    """Get version number, revision number and date from a .py file."""
+
+    with open(filename) as f:
+        for line in f:
+            if line.startswith("__version__"):
+                version_nr = line.split("'")[1]
+            if line.startswith("__revision__"):
+                revision_nr = line.split("'")[1]
+            if line.startswith("__date__"):
+                date = line.split("'")[1]
+    return version_nr, revision_nr, date
+
+def run():
+    """Run the setup."""
+
+    setup(name='expyriment',
+          version=version_nr,
+          description=description,
+          author=author,
+          author_email=author_email,
+          license=license,
+          url=url,
+          packages=packages,
+          package_dir=package_dir,
+          package_data=package_data,
+          data_files=data_files,
+          install_requires=install_requires,
+          extras_require=extras_require,
+          cmdclass=cmdclass)
+
+
 if __name__=="__main__":
-    # Check if we are building/installing from unreleased code
-    version_nr = get_version_from_file("expyriment/__init__.py")
-    warning = ""
-    if version_nr == '':
-        # Try to create html documentation
-        html_created = False
-        cwd = os.getcwd()
-        try:
-            copytree('expyriment', 'documentation/sphinx/expyriment')
-            os.chdir('documentation/sphinx/')
-            call([sys.executable, "./create_rst_api_reference.py"])
-            call(["sphinx-build", "-b", "html", "-d", "_build/doctrees", ".", "_build/html"])
-            os.chdir(cwd)
-            data_files.append(('share/expyriment/documentation/html',
-                               glob('documentation/sphinx/_build/html/*.*')))
-            data_files.append(('share/expyriment/documentation/html/_downloads',
-                               glob('documentation/sphinx/_build/html/_downloads/*.*')))
-            data_files.append(('share/expyriment/documentation/html/_images',
-                               glob('documentation/sphinx/_build/html/_images/*.*')))
-            data_files.append(('share/expyriment/documentation/html/_sources',
-                               glob('documentation/sphinx/_build/html/_sources/*.*')))
-            data_files.append(('share/expyriment/documentation/html/_static',
-                               glob('documentation/sphinx/_build/html/_static/*.*')))
-            data_files.append(('share/expyriment/documentation/html/_static/css',
-                               glob('documentation/sphinx/_build/html/_static/css/*.*')))
-            data_files.append(('share/expyriment/documentation/html/_static/fonts',
-                               glob('documentation/sphinx/_build/html/_static/fonts/*.*')))
-            data_files.append(('share/expyriment/documentation/html/_static/js',
-                               glob('documentation/sphinx/_build/html/_static/js/*.*')))
-            html_created = True
-        except:
-            warning = "HTML documentation NOT created! (sphinx and numpydoc installed?)"
-            os.chdir(cwd)
 
-        # clean up sphinx folder
-        rmtree("documentation/sphinx/build", ignore_errors=True)
-        rmtree("documentation/sphinx/expyriment", ignore_errors=True)
-        for file_ in glob("documentation/sphinx/expyriment.*"):
-            remove_file(file_)
-        remove_file("documentation/sphinx/Changelog.rst")
-        remove_file("documentation/sphinx/CommandLineInterface.rst")
+    # Check if we are building/installing from built a archive/distribution
+    version_nr, revision_nr, date = get_version_info_from_file("expyriment/__init__.py")
+    if not version_nr == '':
+        cmdclass={'install': Install, 
+                  'bdist_wininst': Wininst,
+                  'install_data': InstallData,}
+        run()
+        message = "from built archive/distribution"
 
-        # Try to add version_nr and date stamp from Git and build/install
-        try:
-            proc = Popen(['git', 'rev-list', '--max-parents=0', 'HEAD'],
-                         stdout=PIPE, stderr=PIPE)
-            initial_revision = proc.stdout.readline()
-            if not b'e21fa0b4c78d832f40cf1be1d725bebb2d1d8f10' in \
-                                                            initial_revision:
-                raise Exception
-            version_nr = get_version_from_git()
-            revision_nr = get_revision_from_git()
-            date = get_date_from_git()
-            # Build
-            x = setup(name='expyriment',
-                      version=version_nr,
-                      description=description,
-                      author=author,
-                      author_email=author_email,
-                      license=license,
-                      url=url,
-                      packages=packages,
-                      package_dir=package_dir,
-                      package_data=package_data,
-                      data_files=data_files,
-                      install_requires=install_requires,
-                      extras_require=extras_require,
-                      cmdclass={'build_py': Build, 'install': Install,
-                                'bdist_wininst': Wininst}
-            )
-
-            print("")
-            print("Expyriment Version: [{0}] (from repository)".format(
-                version_nr))  # version_nr should be easy to parse
-        except:
-            raise RuntimeError("Building from repository failed!")
-
-    # If not, we are building/installing from a released download
+    # If not, we are building/installing from source
     else:
-        # Build
-        setup(name='expyriment',
-              version=version_nr,
-              description=description,
-              author=author,
-              author_email=author_email,
-              license=license,
-              url=url,
-              packages=packages,
-              package_dir=package_dir,
-              package_data=package_data,
-              data_files=data_files,
-              install_requires=install_requires,
-              extras_require=extras_require,
-              cmdclass={'install': Install, 'bdist_wininst': Wininst}
-        )
+        cmdclass={'sdist': Sdist,
+                  'build_py': Build,
+                  'install': Install,
+                  'bdist_wininst': Wininst,
+                  'install_data': InstallData}
 
+        # Are we building/installing from a source archive/distribution?
+        version_nr, revision_nr, date = get_version_info_from_release_info()
+        if not date.startswith("$Format:"):
+            run()
+            message = "from source archive/distribution"
 
-        print("")
-        print("Expyriment Version: [{0}]".format(version_nr))
-
-    if len(warning)>0:
+        # Are we building/installing from the GitHub repository?
+        else:
+            if True:
+                proc = Popen(['git', 'rev-list', '--max-parents=0', 'HEAD'],
+                             stdout=PIPE, stderr=PIPE)
+                initial_revision = proc.stdout.readline()
+                if not b'e21fa0b4c78d832f40cf1be1d725bebb2d1d8f10' in \
+                                                                initial_revision:
+                    raise Exception
+                version_nr, revision_nr, date = get_version_info_from_git()
+                run()
+                message = "from repository"
+            else:
+                raise RuntimeError("Building/Installing Expyriment failed!")
+   
+    print("")
+    print("Expyriment Version: [{0}] ({1})".format( version_nr, message))
+    try:
         print("Warning:", warning)
+    except:
+        pass


### PR DESCRIPTION
This is an attempt to have installable source archives (e.g. download from GitHub) with correct version numbers. This is achieved via using the `export-subst` option in git, which will substitute certain fields with certain information when calling `git archive` (which is how GitHub creates their downloads).

---

**Please review/discuss before merging!**

---

# Version number scheme for Releases

1. Wheel
   `0.9.0`

2. Source Distribution
   `0.9.0`

3. GitHub repository
   `0.9.0`

4. GitHub Source Archive
   `0.9.0`

This is all fine. Official releases will have the same version number, revision number and date, no matter from which code you install. That is also true for downloading the `.tar` or `.zip` archive from the GitHub release page.

# Version number scheme for Snapshots

1. Wheel
   `0.9.0-7-g12345678` (alternatives: `0.9.0+` or `0.0.0`)

2. Source Distribution
   `0.9.0-7-g12345678` (alternatives: `0.9.0+` or `0.0.0`)

3. GitHub repository
   `0.9.0-7-g12345678` (alternatives: `0.9.0+` or `0.0.0`)

4. GitHub Source Archive
   `0.9.0-0-g12345678` (alternatives: `0.9.0+` or `0.0.0`, `0.9.0-?-g12345678`)

Here things are a bit more tricky. In particular, the `export-subst` done during `git archive` does not give the full `git describe` information. Hence, creating the version number for Source Archive snapshots (e.g. GitHub download) relies on info in `README.md`. I take the version number from there and put it together with the hash. The missing information is how many commits this is behind the last tag, and I set this part to `0` at the moment.

Alternatively, since the current `git describe` style version numbers for snapshots are not PEP440 compatible anyway, we might want to discuss going to a different scheme altogether, which might also allow to have the same version name for source archives as for the others. See also https://trello.com/c/SrZvRrSf/265-snapshot-version-numbers.