### PR TITLE
adapted all methods to use correct coordinate system

### DIFF
--- a/expyriment/cli.py
+++ b/expyriment/cli.py
@@ -278,6 +278,15 @@ functions to join the data output.""",
         _secure_hash.secure_hashes = secure_hashes
         _secure_hash.cout_hashes()
 
+        def execfile(filepath, globals=None, locals=None):
+            if globals is None:
+                globals = {}
+            globals.update({
+                "__file__": filepath,
+                "__name__": "__main__",
+            })
+            with open(filepath, 'rb') as file:
+                exec(compile(file.read(), filepath, 'exec'), globals, locals)
         execfile(pyfile)
 
 

--- a/expyriment/io/_screen.py
+++ b/expyriment/io/_screen.py
@@ -20,6 +20,7 @@ except ImportError:
 
 from .. import _internals
 from ._input_output import Output
+from ..misc.geometry import position2coordinate
 
 
 class Screen(Output):
@@ -213,12 +214,12 @@ machine!")
 
         if not self._open_gl:
             rectangles = []
-            half_screen_size = (self.size[0] // 2, self.size[1] // 2)
             for stim in stimuli:
                 pos = stim.absolute_position
                 stim_size = stim.surface_size
-                rect_pos = (pos[0] + half_screen_size[0] - stim_size[0] // 2,
-                            - pos[1] + half_screen_size[1] - stim_size[1] // 2)
+                rect_pos = position2coordinate(pos, self.size)
+                rect_pos[0] -= stim_size[0] // 2
+                rect_pos[1] -= stim_size[1] // 2
                 rectangles.append(pygame.Rect(rect_pos, stim_size))
             pygame.display.update(rectangles)
             if self._logging:
@@ -249,13 +250,13 @@ machine!")
         screen of your current  experiment.
 
         """
-        
+
         return self._window_size[1] // 2
 
     @property
     def size(self):
         """Getter for the size of the screen.
-        
+
         Notes
         -----
         Each initialized experiment has its one screen (exp.screen). Please use always the

--- a/expyriment/stimuli/_visual.py
+++ b/expyriment/stimuli/_visual.py
@@ -912,10 +912,13 @@ class Visual(Stimulus):
         self._parent = stimulus
         rect = pygame.Rect((0, 0), self.surface_size)
         stimulus_surface_size = stimulus.surface_size
-        rect.center = geometry.position2coordinate(self.position,
-                                                   stimulus_surface_size)
-        #rect.center = [self.position[0] + stimulus_surface_size[0] // 2,
-        #               - self.position[1] + stimulus_surface_size[1] // 2]
+        x, y = geometry.position2coordinate(self.position,
+                                            stimulus_surface_size)
+        if stimulus_surface_size[0] % 2 == 0:
+            x += 1
+        if stimulus_surface_size[1] % 2 == 0:
+            y += 1
+        rect.center = (x, y)
         stimulus._get_surface().blit(self._get_surface(), rect)
         if self._logging:
             _internals.active_exp._event_file_log(
@@ -1173,10 +1176,14 @@ class Visual(Stimulus):
             screen = _internals.active_exp.screen.surface
             rect = pygame.Rect((0, 0), self.surface_size)
             screen_size = screen.get_size()
-            rect.center = geometry.position2coordinate(self.position,
-                                                       screen_size)
-            rect.center = [self.position[0] + screen_size[0] // 2,
-                           - self.position[1] + screen_size[1] // 2]
+            x, y = geometry.position2coordinate(self.position, screen_size)
+            if screen_size[0] % 2 == 0:
+                x += 1
+            if screen_size[1] % 2 == 0:
+                y += 1
+            rect.center = (x, y)
+            #rect.center = [self.position[0] + screen_size[0] // 2,
+            #               - self.position[1] + screen_size[1] // 2]
             screen.blit(self._get_surface(), rect)
         if self._logging:
             _internals.active_exp._event_file_log("Stimulus,presented,{0}"\

--- a/expyriment/stimuli/_visual.py
+++ b/expyriment/stimuli/_visual.py
@@ -239,7 +239,7 @@ class Visual(Stimulus):
             warn_message = "Stimulus created before initializing " + \
                            "(experiment defaults won't apply)!"
             print("Warning: " + warn_message)
-            
+
     _compression_exception_message = "Cannot call {0} on compressed stimuli!"
 
     def __del__(self):
@@ -293,12 +293,12 @@ class Visual(Stimulus):
     @property
     def absolute_position(self):
         """Getter for absolute_position.
-        
+
         Notes
         -----
         The absolute position differs for instance from the (relative) position, if the
         stimulus is plotted ontop of another stimulus, which has not the position (0,0).
-        
+
         """
 
         if self._parent:
@@ -345,7 +345,7 @@ class Visual(Stimulus):
 
     def get_pixel_array(self):
         """Return a 2D array referencing the surface pixel data.
-        
+
         Returns
         -------
         pixel_array: Pygame.PixelArray
@@ -358,7 +358,7 @@ class Visual(Stimulus):
         """
 
         return pygame.PixelArray(self.get_surface_copy())
-    
+
     def get_surface_array(self, replace_transparent_with_colour=None):
         """Get a 3D array containing the surface pixel data.
 
@@ -605,7 +605,7 @@ class Visual(Stimulus):
             the other stimulus
         mode : mode (str), optional
             "visible": based on non-transparent pixels or
-            "rectangle": based on pixels in pygame surface
+            "surface": based on pixels in pygame surface
             (default = visible")
 
         Returns
@@ -623,12 +623,22 @@ class Visual(Stimulus):
             screen_size = _internals.active_exp.screen.surface.get_size()
             self_size = self.surface_size
             other_size = stimulus.surface_size
-            self_pos = (
-                self.position[0] + screen_size[0] // 2 - self_size[0] // 2,
-                - self.position[1] + screen_size[1] // 2 - self_size[1] // 2)
-            other_pos = (
-                stimulus.position[0] + screen_size[0] // 2 - other_size[0] // 2,
-                - stimulus.position[1] + screen_size[1] // 2 - other_size[1] // 2)
+            self_pos = geometry.position2coordinate(self.position,
+                                                    screen_size)
+            self_pos[0] -= self_size[0] // 2
+            self_pos[1] -= self_size[1] // 2
+            if self_size[0] % 2 == 0:
+                self_pos[0] += 1
+            if self_size[1] % 2 == 0:
+                self_pos[1] += 1
+            other_pos = geometry.position2coordinate(stimulus.position,
+                                                     screen_size)
+            other_pos[0] -= other_size[0] // 2
+            other_pos[1] -= other_size[1] // 2
+            if other_size[0] % 2 == 0:
+                other_pos[0] += 1
+            if other_size[1] % 2 == 0:
+                other_pos[1] += 1
             offset = (-self_pos[0] + other_pos[0], -self_pos[1] + other_pos[1])
             self_mask = pygame.mask.from_surface(self._get_surface())
             other_mask = pygame.mask.from_surface(stimulus._get_surface())
@@ -640,17 +650,25 @@ class Visual(Stimulus):
 
         elif mode == "surface":
             screen_size = _internals.active_exp.screen.surface.get_size()
-            sx = self.absolute_position[0] + screen_size[0] // 2
-            sy = self.absolute_position[1] + screen_size[1] // 2
+            sx, sy = geometry.coordinate2position(self.absolute_position,
+                                                  screen_size)
             selfrect = pygame.Rect((0, 0), self.surface_size)
+            if self.surface_size[0] % 2 == 0:
+                sx += 1
+            if self.surface_size[1] % 2 == 0:
+                sy += 1
             selfrect.center = (sx, sy)
-            ox = stimulus.absolute_position[0] + screen_size[0] // 2
-            oy = stimulus.absolute_position[1] + screen_size[1] // 2
+            ox, oy = geometry.coordinate2position(stimulus.absolute_position,
+                                                  screen_size)
+            if stimulus.surface_size[0] % 2 == 0:
+                ox += 1
+            if stimulus.surface_size[1] % 2 == 0:
+                oy += 1
             stimrect = pygame.Rect((0, 0), stimulus.surface_size)
             stimrect.right = stimrect.right + 1
             stimrect.bottom = stimrect.bottom + 1
             stimrect.center = (ox, oy)
-            if selfrect.contains(stimrect):
+            if stimrect.contains(selfrect):
                 return True
             else:
                 return False
@@ -682,7 +700,7 @@ class Visual(Stimulus):
         -----
         Depending on the size of the stimulus, this method may take some time
         to compute!
-        
+
         CAUTION: Please note that if a stimulus is plotted on another smaller
         stimulus, such that it is not fully visible on screen, this method will
         still check overlapping of the full stimulus! Due to a current bug in
@@ -695,23 +713,43 @@ class Visual(Stimulus):
             self_size = self.surface_size
             other_size = stimulus.surface_size
             if use_absolute_position:
-                self_pos = (self.absolute_position[0] + screen_size[0] // 2 -
-                            self_size[0] // 2,
-                            - self.absolute_position[1] + screen_size[1] // 2 -
-                            self_size[1] // 2)
-                other_pos = (stimulus.absolute_position[0] + screen_size[0] // 2
-                             - other_size[0] // 2,
-                             - stimulus.absolute_position[1] + screen_size[1] //
-                             2 - other_size[1] // 2)
+                self_pos = geometry.position2coordinate(
+                    self.absolute_position, screen_size)
+                self_pos[0] -= self_size[0] // 2
+                self_pos[1] -= self_size[1] // 2
+                if self_size[0] % 2 == 0:
+                    self_pos[0] += 1
+                if self_size[1] % 2 == 0:
+                    self_pos[1] += 1
+
+                other_pos = geometry.position2coordinate(
+                    stimulus.absolute_position, screen_size)
+                other_pos[0] -= other_size[0] // 2
+                other_pos[1] -= other_size[1] // 2
+                if other_size[0] % 2 == 0:
+                    other_pos[0] += 1
+                if other_size[1] % 2 == 0:
+                    other_pos[1] += 1
+
             else:
-                self_pos = (self.position[0] + screen_size[0] // 2 -
-                            self_size[0] // 2,
-                            - self.position[1] + screen_size[1] // 2 -
-                            self_size[1] // 2)
-                other_pos = (stimulus.position[0] + screen_size[0] // 2 -
-                             other_size[0] // 2,
-                             - stimulus.position[1] + screen_size[1] // 2 -
-                             other_size[1] // 2)
+                self_pos = geometry.position2coordinate(
+                    self.position, screen_size)
+                self_pos[0] -= self_size[0] // 2
+                self_pos[1] -= self_size[1] // 2
+                if self_size[0] % 2 == 0:
+                    self_pos[0] += 1
+                if self_size[1] % 2 == 0:
+                    self_pos[1] += 1
+
+                other_pos = geometry.position2coordinate(
+                    stimulus.position, screen_size)
+                other_pos[0] -= other_size[0] // 2
+                other_pos[1] -= other_size[1] // 2
+                if other_size[0] % 2 == 0:
+                    other_pos[0] += 1
+                if other_size[1] % 2 == 0:
+                    other_pos[1] += 1
+
             offset = (-self_pos[0] + other_pos[0], -self_pos[1] + other_pos[1])
             self_mask = pygame.mask.from_surface(self._get_surface())
             other_mask = pygame.mask.from_surface(stimulus._get_surface())
@@ -720,21 +758,30 @@ class Visual(Stimulus):
                 return True, overlap
             else:
                 return False, overlap
+
         elif mode == "surface":
             screen_size = _internals.active_exp.screen.surface.get_size()
             if use_absolute_position:
-                sx = self.absolute_position[0] + screen_size[0] // 2
-                sy = self.absolute_position[1] + screen_size[1] // 2
-                ox = stimulus.absolute_position[0] + screen_size[0] // 2
-                oy = stimulus.absolute_position[1] + screen_size[1] // 2
+                sx, sy = geometry.coordinate2position(
+                    self.absolute_position, screen_size)
+                ox, oy = geometry.coordinate2position(
+                    stimulus.absolute_position, screen_size)
             else:
-                sx = self.position[0] + screen_size[0] // 2
-                sy = self.position[1] + screen_size[1] // 2
-                ox = stimulus.position[0] + screen_size[0] // 2
-                oy = stimulus.position[1] + screen_size[1] // 2
+                sx, sy = geometry.coordinate2position(
+                    self.position, screen_size)
+                ox, oy = geometry.coordinate2position(
+                    stimulus.position, screen_size)
             selfrect = pygame.Rect((0, 0), self.surface_size)
+            if self.surface_size[0] % 2 == 0:
+                sx += 1
+            if self.surface_size[1] % 2 == 0:
+                sy += 1
             selfrect.center = (sx, sy)
             stimrect = pygame.Rect((0, 0), stimulus.surface_size)
+            if stimulus.surface_size[0] % 2 == 0:
+                ox += 1
+            if stimulus.surface_size[1] % 2 == 0:
+                oy += 1
             stimrect.right = stimrect.right + 1
             stimrect.bottom = stimrect.bottom + 1
             stimrect.center = (ox, oy)
@@ -771,24 +818,33 @@ class Visual(Stimulus):
         stimulus, such that it is not fully visible on screen, this method will
         still check overlapping of the full stimulus! Due to a current bug in
         Pygame, we can right now not change this.
-        
+
         """
 
         if mode == "visible":
             screen_size = _internals.active_exp.screen.surface.get_size()
             self_size = self.surface_size
             if use_absolute_position:
-                self_pos = (
-                    (self.absolute_position[0] + screen_size[0] // 2) -
-                    self_size[0] // 2,
-                    (-self.absolute_position[1] + screen_size[1] // 2) -
-                    self_size[1] // 2)
+                self_pos = geometry.position2coordinate(
+                    self.absolute_position, screen_size)
+                self_pos[0] -= self_size[0] // 2
+                self_pos[1] -= self_size[1] // 2
+                if self_size[0] % 2 == 0:
+                    self_pos[0] += 1
+                if self_size[1] % 2 == 0:
+                    self_pos[1] += 1
+
             else:
-                self_pos = (
-                    (self.position[0] + screen_size[0] // 2) - self_size[0] // 2,
-                    (-self.position[1] + screen_size[1] // 2) - self_size[1] // 2)
-            pos = (position[0] + screen_size[0] // 2,
-                   - position[1] + screen_size[1] // 2)
+                self_pos = geometry.position2coordinate(
+                    self.position, screen_size)
+                self_pos[0] -= self_size[0] // 2
+                self_pos[1] -= self_size[1] // 2
+                if self_size[0] % 2 == 0:
+                    self_pos[0] += 1
+                if self_size[1] % 2 == 0:
+                    self_pos[1] += 1
+
+            pos = geometry.position2coordinate(position, screen_size)
             offset = (int(pos[0] - self_pos[0]), int(pos[1] - self_pos[1]))
             self_mask = pygame.mask.from_surface(self._get_surface())
             overlap = False
@@ -803,15 +859,22 @@ class Visual(Stimulus):
         elif mode == "surface":
             screen_size = _internals.active_exp.screen.surface.get_size()
             if use_absolute_position:
-                sx = self.absolute_position[0] + screen_size[0] // 2
-                sy = self.absolute_position[1] + screen_size[1] // 2
+                sx, sy = geometry.coordinate2position(self.absolute_position,
+                                                      screen_size)
             else:
-                sx = self.position[0] + screen_size[0] // 2
-                sy = self.position[1] + screen_size[1] // 2
+                sx, sy = geometry.coordinate2position(self.position,
+                                                      screen_size)
             selfrect = pygame.Rect((0, 0), self.surface_size)
+            if self.surface_size[0] % 2 == 0:
+                sx += 1
+            if self.surface_size[1] % 2 == 0:
+                sy += 1
             selfrect.center = (sx, sy)
+            p = geometry.coordinate2position(position, screen_size)
             p = (position[0] + screen_size[0] // 2,
                  position[1] + screen_size[1] // 2)
+            p = geometry.coordinate2position(position, screen_size)
+            print(sx, sy, p)
             if selfrect.collidepoint(p):
                 return True
             else:
@@ -849,8 +912,10 @@ class Visual(Stimulus):
         self._parent = stimulus
         rect = pygame.Rect((0, 0), self.surface_size)
         stimulus_surface_size = stimulus.surface_size
-        rect.center = [self.position[0] + stimulus_surface_size[0] // 2,
-                       - self.position[1] + stimulus_surface_size[1] // 2]
+        rect.center = geometry.position2coordinate(self.position,
+                                                   stimulus_surface_size)
+        #rect.center = [self.position[0] + stimulus_surface_size[0] // 2,
+        #               - self.position[1] + stimulus_surface_size[1] // 2]
         stimulus._get_surface().blit(self._get_surface(), rect)
         if self._logging:
             _internals.active_exp._event_file_log(
@@ -1108,6 +1173,8 @@ class Visual(Stimulus):
             screen = _internals.active_exp.screen.surface
             rect = pygame.Rect((0, 0), self.surface_size)
             screen_size = screen.get_size()
+            rect.center = geometry.position2coordinate(self.position,
+                                                       screen_size)
             rect.center = [self.position[0] + screen_size[0] // 2,
                            - self.position[1] + screen_size[1] // 2]
             screen.blit(self._get_surface(), rect)

--- a/expyriment/stimuli/_visual.py
+++ b/expyriment/stimuli/_visual.py
@@ -58,6 +58,19 @@ class _LaminaPanelSurface(object):
 
         """
 
+
+        surface_size = surface.get_size()
+        if surface_size[0] == 1:
+            rect = pygame.Rect((0, 0), surface_size)
+            s = pygame.surface.Surface((2, surface_size[1]), pygame.SRCALPHA).convert_alpha()
+            s.blit(surface, rect)
+            surface = s
+        surface_size = surface.get_size()
+        if surface_size[1] == 1:
+            rect = pygame.Rect((0, 0), surface_size)
+            s = pygame.surface.Surface((surface_size[0], 2), pygame.SRCALPHA).convert_alpha()
+            s.blit(surface, rect)
+            surface = s
         self._txtr = Visual._load_texture(surface)
         if isinstance(surface, pygame.Surface):
             self._winsize = surface.get_size()
@@ -99,30 +112,31 @@ class _LaminaPanelSurface(object):
         """Recalc where in modelspace quad needs to be to fill screen."""
 
         screensize = pygame.display.get_surface().get_size()
-        bottomleft = oglu.gluUnProject(screensize[0] / 2 - \
-                                       self._winsize[0] / 2 + \
+        bottomleft = oglu.gluUnProject(screensize[0] // 2 - \
+                                       int(round(self._winsize[0] / 2)) + \
                                        self._position[0],
-                                       screensize[1] / 2 - \
-                                       int(round(self._winsize[1] / 2.0)) + \
+                                       screensize[1] // 2 - \
+                                       self._winsize[1] // 2 + \
                                        self._position[1], 0)
-        bottomright = oglu.gluUnProject(screensize[0] / 2 + \
-                                        int(round(self._winsize[0] / 2.0)) + \
+        bottomright = oglu.gluUnProject(screensize[0] // 2 + \
+                                        self._winsize[0] // 2 + \
                                         self._position[0],
-                                        screensize[1] / 2 - \
-                                        int(round(self._winsize[1] / 2.0)) + \
+                                        screensize[1] // 2 - \
+                                        self._winsize[1] // 2 + \
                                         self._position[1], 0)
-        topleft = oglu.gluUnProject(screensize[0] / 2 - \
-                                    self._winsize[0] / 2 + \
+        topleft = oglu.gluUnProject(screensize[0] // 2 - \
+                                    int(round(self._winsize[0] / 2)) + \
                                     self._position[0],
-                                    screensize[1] / 2 + \
-                                    self._winsize[1] / 2 + \
+                                    screensize[1] // 2 + \
+                                    int(round(self._winsize[1] / 2)) + \
                                     self._position[1], 0)
-        topright = oglu.gluUnProject(screensize[0] / 2 + \
-                                     int(round(self._winsize[0] / 2.0)) + \
+        topright = oglu.gluUnProject(screensize[0] // 2 + \
+                                     self._winsize[0] // 2 + \
                                      self._position[0],
-                                     screensize[1] / 2 + \
-                                     self._winsize[1] / 2 + \
+                                     screensize[1] // 2 + \
+                                     int(round(self._winsize[1] / 2)) + \
                                      self._position[1], 0)
+
 
         self.dims = topleft, topright, bottomright, bottomleft
         width = topright[0] - topleft[0]
@@ -914,9 +928,9 @@ class Visual(Stimulus):
         stimulus_surface_size = stimulus.surface_size
         x, y = geometry.position2coordinate(self.position,
                                             stimulus_surface_size)
-        if stimulus_surface_size[0] % 2 == 0:
+        if self.surface_size[0] % 2 == 0:
             x += 1
-        if stimulus_surface_size[1] % 2 == 0:
+        if self.surface_size[1] % 2 == 0:
             y += 1
         rect.center = (x, y)
         stimulus._get_surface().blit(self._get_surface(), rect)
@@ -1177,13 +1191,11 @@ class Visual(Stimulus):
             rect = pygame.Rect((0, 0), self.surface_size)
             screen_size = screen.get_size()
             x, y = geometry.position2coordinate(self.position, screen_size)
-            if screen_size[0] % 2 == 0:
+            if self.surface_size[0] % 2 == 0:
                 x += 1
-            if screen_size[1] % 2 == 0:
+            if self.surface_size[1] % 2 == 0:
                 y += 1
             rect.center = (x, y)
-            #rect.center = [self.position[0] + screen_size[0] // 2,
-            #               - self.position[1] + screen_size[1] // 2]
             screen.blit(self._get_surface(), rect)
         if self._logging:
             _internals.active_exp._event_file_log("Stimulus,presented,{0}"\


### PR DESCRIPTION
The following methods have been adapted:
- io.screen.update_stimuli
- stimuli._visual.present
- stimuli._visual.plot
- stimuli._visual.inside_stimulus
- stimuli._visual.overlapping_with_stimulus
- stimuli._visual.overlapping_with_position

Furthermore, there was a bug in OpenGL textures. Positions on screen were a pixel off with OpenGL enabled, compared to running without OpenGL! This should now be fixed. I additionally added a hack to have surfaces with only one pixel in either dimension converted correctly into an OpenGL texture.

**Please test!**