### PR TITLE
Fix shape bug

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -42,6 +42,7 @@ Changed:
 - trial.get_factor, block.get_factor, experiment.get_bws_factor now raises an
   exception, if the factor is not defined. This can be suppressed by using the
   parameter return_none_if_not_defined
+- stimuli.Shape.rect is now a pygame.Rect()
 
 Fixed:
 - Adding field bug in TouchscreenButtonBox

--- a/expyriment/stimuli/_fixcross.py
+++ b/expyriment/stimuli/_fixcross.py
@@ -85,8 +85,8 @@ class FixCross(Shape):
                     (0, line_width),
                     (x, 0)]
         self.add_vertices(vertex_list=vertices)
+
         print(self.xy_points)
-        print(self.xy_points_on_screen)
 
     @property
     def size(self):

--- a/expyriment/stimuli/_fixcross.py
+++ b/expyriment/stimuli/_fixcross.py
@@ -73,17 +73,20 @@ class FixCross(Shape):
         self._size = size
         x = (self._size[0] - line_width) // 2
         y = (self._size[1] - line_width) // 2
-        self.add_vertex((line_width, 0))
-        self.add_vertex((0, -y))
-        self.add_vertex((x, 0))
-        self.add_vertex((0, -line_width))
-        self.add_vertex((-x, 0))
-        self.add_vertex((0, -y))
-        self.add_vertex((-line_width, 0))
-        self.add_vertex((0, y))
-        self.add_vertex((-x, 0))
-        self.add_vertex((0, line_width))
-        self.add_vertex((x, 0))
+        vertices = [(line_width, 0),
+                    (0, -y),
+                    (x, 0),
+                    (0, -line_width),
+                    (-x, 0),
+                    (0, -y),
+                    (-line_width, 0),
+                    (0, y),
+                    (-x, 0),
+                    (0, line_width),
+                    (x, 0)]
+        self.add_vertices(vertex_list=vertices)
+        print(self.xy_points)
+        print(self.xy_points_on_screen)
 
     @property
     def size(self):

--- a/expyriment/stimuli/_fixcross.py
+++ b/expyriment/stimuli/_fixcross.py
@@ -86,7 +86,6 @@ class FixCross(Shape):
                     (x, 0)]
         self.add_vertices(vertex_list=vertices)
 
-        print(self.xy_points)
 
     @property
     def size(self):

--- a/expyriment/stimuli/_shape.py
+++ b/expyriment/stimuli/_shape.py
@@ -27,6 +27,8 @@ from .. import _internals
 from ..misc._timer import get_time
 from ..misc.geometry import XYPoint, lines_intersect, position2coordinates
 
+FIX_PYGAME_POLYGON_BUG = True
+
 class Shape(Visual):
     """A class implementing a shape."""
 
@@ -189,8 +191,12 @@ class Shape(Visual):
 
     @property
     def rect(self):
-        """Getter for rect =(top, left, width, right).
-        From version 0.9.1 on this is a pygame.Rect
+        """Getter for bouncing rectangular
+        rect = pygame.Rect(left, top, width, height)
+
+        Note
+        -----
+        Fom version 0.9.1 on, this is a pygame.Rect
 
         """
 
@@ -575,7 +581,7 @@ class Shape(Visual):
 
     @staticmethod
     def _get_shape_rect(points):
-        """ return pygame.Rect rect (top, left, width, height) around the points."""
+        """ return bouncing rect as pygame.Rect rect (top, left, width, height) around the points."""
 
         t = 0
         l = 0
@@ -606,11 +612,14 @@ class Shape(Visual):
 
         line_width = int(self._line_width)
         # Draw the rect
-        s = (self.width  + line_width, self.height + line_width)  # FIXME if width+1 it is OK
-        surface = pygame.surface.Surface(s,
+        target_surface_size = (self.width  + line_width, self.height + line_width)  # width + 1 to fix pygame polygon bug
+        if FIX_PYGAME_POLYGON_BUG:
+            target_surface_size = (target_surface_size[0] + 1, target_surface_size[1])
+
+        surface = pygame.surface.Surface(target_surface_size,
                                         pygame.SRCALPHA).convert_alpha()
-        #surface.fill((255, 0, 0)) # for debugging only
-        #create polygon
+
+        # create polygon
         poly = []
         for p in self.xy_points: # Convert points_in_pygame_coordinates
             poly.append(self.convert_expyriment_xy_to_surface_xy(p.tuple))
@@ -630,6 +639,7 @@ class Shape(Visual):
                                  int(size[1] / aa_scaling)))
             self._native_scaling = old_scaling
             self._update_points()
+
         return surface
 
 

--- a/expyriment/stimuli/_shape.py
+++ b/expyriment/stimuli/_shape.py
@@ -94,7 +94,7 @@ class Shape(Visual):
 
         self._vertices = []
         self._xy_points = []
-        self._rect = []
+        self._rect = (0, 0, 0, 0)
         self._native_rotation = 0
         self._native_scaling = [1, 1]
         self._native_rotation_centre = (0, 0)
@@ -173,11 +173,11 @@ class Shape(Visual):
 
     @property
     def width(self):
-        return self._rect[3] - self._rect[1]#r-l
+        return self._rect[3] - self._rect[1]  # r-l
 
     @property
     def height(self):
-        return self._rect[0] - self._rect[2]#t-b
+        return self._rect[0] - self._rect[2]  # t-b
 
     @property
     def shape_size(self):
@@ -350,7 +350,7 @@ class Shape(Visual):
 
         self._vertices = []
         self._xy_points = []
-        self._rect = []
+        self._rect = (0, 0, 0, 0)
         self._native_rotation = 0
         self._native_scaling = [1, 1]
         self._native_rotation_centre = (0, 0)
@@ -550,41 +550,41 @@ class Shape(Visual):
     def _update_points(self):
         """Updates the points of the shape and the drawing rect.
 
-        Converts vertex to points, centers points, rotates, calculates rect and
-        clears surface and draw_rotation_point.
-
-         """
+        Converts vertex to points, centers points, rotates, calculates rect
+        """
 
         # Copying and scaling and flipping of vertices
-        tmp_vtx = []
+        tmp_vtx = [] # TODO map function?
         for v in self._vertices:
             v = (v[0] * self._native_scaling[0],
                  v[1] * self._native_scaling[1])
             tmp_vtx.append(v)
 
         # Converts tmp_vtx to points in xy-coordinates
-        xy_p = [XYPoint(0, 0)]
-        for v in map(Shape._compensate_for_pygame_polygon_bug ,tmp_vtx):
+        xy_p = [XYPoint(0, 0)] # TODO map function?
+        for v in tmp_vtx:
             x = (v[0] + xy_p[-1].x)
             y = (v[1] + xy_p[-1].y)
             xy_p.append(XYPoint(x, y))
 
-        xy_p = self._center_points(xy_p)
+        xy_p = Shape._center_points(xy_p)
         if self._native_rotation != 0:
             for x in range(0, len(xy_p)):
                 xy_p[x].rotate(self._native_rotation,
                                self._native_rotation_centre)
 
         self._xy_points = xy_p
-        self._rect = self._make_shape_rect(self.xy_points)
+        self._rect = Shape._make_shape_rect(self.xy_points)
 
-    def _make_shape_rect(self, points):
-        """Four points (geomerty.XYPoint) top, left, bottom, right."""
+    @staticmethod
+    def _make_shape_rect(points):
+        """rect (top, left, bottom, right) around the points."""
 
         t = 0
         l = 0
         r = 0
         b = 0
+
         for p in points:
             if p.x < l:
                 l = p.x
@@ -594,18 +594,21 @@ class Shape(Visual):
                 t = p.y
             elif p.y < b:
                 b = p.y
+
         return (t, l, b, r)
 
-    def _center_points(self, points):
+
+    @staticmethod
+    def _center_points(points):
         """Return centered points (list of geomerty.XYPoint)."""
 
-        t, l, b, r = self._make_shape_rect(points)
-
-        # Stimulus center
-        c = XYPoint(((r - l) / 2.0) - r,
-                                             ((t - b) / 2.0) - t)
+        t, l, b, r = Shape._make_shape_rect(points)
+        w = r-l
+        h = t-b
+        cntr = (l + (w // 2), t - (h // 2))
+        m = XYPoint(x=-1*cntr[0], y=-1*cntr[1])
         for x in range(0, len(points)): # Center points
-            points[x].move(c)
+            points[x].move(m)
         return points
 
     def _create_surface(self):


### PR DESCRIPTION
I rewrote the core functions of shape. It now really does what it should do (check e.g. shape.points_xy) and is a bit optimized. 

However, there the plotting on the correct polygon has obviously  bug in pygame and the resulting width (not height!) of the surface has to be one pixel enlarger than you would expect. see the resutling sizes:
```
print(shape.shape_size)
print(shape.surface_size)
```

It become nice obvious if you plot the new test stimulus (regular comb-like object)
```
expyriment.stimuli.Shape._test(..optional..)
```

and switch of the fixing of the polygon bug in shape.py line 30

What do you think?
