### PR TITLE
Updated help text and init method for Audio class

### DIFF
--- a/expyriment/stimuli/_audio.py
+++ b/expyriment/stimuli/_audio.py
@@ -45,9 +45,11 @@ class Audio(Stimulus):
         Parameters
         ----------
         filename : str
-            the filename
+            the filename. Must be an .ogg or uncompressed .wav file.
 
         """
+        if os.path.splitext(filename)[1] not in ('.wav', '.ogg'):
+            raise ValueError("The audio file must be an .ogg or uncompressed .wav file")
 
         Stimulus.__init__(self, filename)
         self._filename = filename


### PR DESCRIPTION
Updated the help text and init method for Audio class to indicate the filetype must be .ogg or .wav because thats all the `pygame.mixer.Sound` accepts, according to the [the Pygame.mixer.Sound man page](https://www.pygame.org/docs/ref/mixer.html#pygame.mixer.Sound).

Without this check, you get a generic message about bring "unable to open the file" when you try to open e.g., a .mp3 file, which doesn't help anyone figure out the issue.
