### PR TITLE
Exit text_input box when Escape key is pressed

### DIFF
--- a/expyriment/io/_textinput.py
+++ b/expyriment/io/_textinput.py
@@ -483,6 +483,8 @@ class TextInput(Input):
             inkey, string = self._get_key()
             if isinstance(inkey, CallbackQuitEvent):
                 return None
+            elif inkey == pygame.K_ESCAPE:
+                return ''
             elif inkey == pygame.K_BACKSPACE:
                 self._user = self._user[0:-1]
             elif inkey == pygame.K_RETURN or inkey == pygame.K_KP_ENTER:


### PR DESCRIPTION
When using the `text_input` class, I noticed that pressing the Escape key did not cause the function to quit collecting input and return an empty string, as the documentation for the `.get()` method described. Instead, it treated the Escape key presses normally, and went ahead trying to render them, resulting in displays such as the following:


![text_input_escape](https://user-images.githubusercontent.com/9057226/51769071-0616c800-20b0-11e9-97a3-ec006a4963a3.PNG)

You can test this out using this small program:
```python
import expyriment

expyriment.control.set_develop_mode(on=True)
exp = expyriment.design.Experiment(name="text_input Test")
expyriment.control.initialize(exp)
expyriment.control.start(skip_ready_screen=True, auto_create_subject_id=True)


txt_input = expyriment.io.TextInput(message="Press Escape to quit.",
                                    message_text_size=24,
                                    user_text_size=48,
                                    gap=20)

answer = txt_input.get()
print(answer)
answer.__str__()

expyriment.control.end()
```

This commit brings the function's behavior in line with the documentation.