### PR TITLE
FIX: process_control_keys forgetting quit callback

### DIFF
--- a/expyriment/io/_keyboard.py
+++ b/expyriment/io/_keyboard.py
@@ -87,7 +87,7 @@ class Keyboard(Input):
         else:
             for event in pygame.event.get(pygame.KEYDOWN):
                 # recursion
-                return Keyboard.process_control_keys(event)
+                return Keyboard.process_control_keys(event, quit_confirmed_function)
 
         return False
 


### PR DESCRIPTION
io.keyboard.Keyboard.process_control_keys shouldn't forget quit_confirmed_function after recursion