### PR TITLE
time_perf_counter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,8 @@ Changed:
 - stimuli.Video: attempting to downloaded a missing ffmpeg binary only when
   initializing a Video stimulus with the "mediadecoder" backend
 - misc.HSVColour has been removed and merged with the colour class (misc.colour)
+- Fallback function for the high-precision time uses now time.perf_counter() under
+  Python 3.3+
 
 Fixed:
 - Adding field bug in TouchscreenButtonBox

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -32,6 +32,8 @@ New Features:
   has been removed.
      
 Changed:
+- Python's time.perf_counter() function will be used as high-precision timer
+  if it exists (that is, for Python 3.3+)
 - major rewrite of stimuli.Shape, bug fixes, see improved documentation 
 - extras
     - extras need to be explicitly imported
@@ -58,8 +60,6 @@ Changed:
 - stimuli.Video: attempting to downloaded a missing ffmpeg binary only when
   initializing a Video stimulus with the "mediadecoder" backend
 - misc.HSVColour has been removed and merged with the colour class (misc.colour)
-- Fallback function for the high-precision time uses now time.perf_counter() under
-  Python 3.3+
 
 Fixed:
 - Adding field bug in TouchscreenButtonBox

--- a/expyriment/misc/_timer.py
+++ b/expyriment/misc/_timer.py
@@ -102,15 +102,29 @@ else:
 
 if _use_time_module:
     import time
-    warn_message = "Failed to initialize monotonic timer. Python's time module will be use."
-    print("Warning: " + warn_message)
-    if platform == 'win32':
-        def get_time():
-            """Get high-resolution time stamp (float) """
-            return time.clock() #TODO: deprecated method with PY3.3+
-                                # change to pref_counter() or time_ns(PY3.6+)
+    try:
+        from time import perf_counter
+    except:
+        perf_counter = None
+
+    if perf_counter is None:
+        if platform == 'win32':
+            timer_used = "clock"
+            def get_time():
+                """Get high-resolution time stamp (float) """
+                return time.clock()
+
+        else:
+            timer_used = "time"
+            def get_time():
+                """Get high-resolution time stamp (float) """
+                return time.time()
 
     else:
+        timer_used = "perf_counter"
         def get_time():
             """Get high-resolution time stamp (float) """
-            return time.time() # TODO: change to pref_counter() or time_ns(PY3.6+)
+            return time.perf_counter()
+
+    print("Warning: Failed to initialize monotonic timer. Python's "
+                         "time.{}() function will be use.".format(timer_used))

--- a/expyriment/misc/_timer.py
+++ b/expyriment/misc/_timer.py
@@ -19,95 +19,100 @@ __version__ = ''
 __revision__ = ''
 __date__ = ''
 
+# use perf_counter if it exists and works
 try:
-    import ctypes
+    from time import perf_counter
+    def get_time():
+        """Get high-resolution time stamp (float) """
+        return time.perf_counter()
+
+    get_time()
+
 except:
-    ctypes = None  # Does not exist on Android
-import os
-from sys import platform
-
-_use_time_module = False
-
-if platform == 'darwin':
-    # MAC
-    try:
-        class _TimeBase(ctypes.Structure):
-            _fields_ = [
-                ('numer', ctypes.c_uint),
-                ('denom', ctypes.c_uint)
-            ]
-
-        _libsys_c = ctypes.CDLL('/usr/lib/system/libsystem_c.dylib')
-        _libsys_kernel = ctypes.CDLL('/usr/lib/system/libsystem_kernel.dylib')
-        _mac_abs_time = _libsys_c.mach_absolute_time
-        _mac_timebase_info = _libsys_kernel.mach_timebase_info
-        _time_base = _TimeBase()
-        if (_mac_timebase_info(ctypes.pointer(_time_base)) != 0):
-            _use_time_module = True
-
-        def get_time():
-            """Get high-resolution monotonic time stamp (float) """
-            _mac_abs_time.restype = ctypes.c_ulonglong
-            return float(_mac_abs_time()) * _time_base.numer / (_time_base.denom * 1e9)
-        get_time()
-    except:
-        _use_time_module = True
-
-elif platform.startswith('linux'):
-    # real OS
-    _CLOCK_MONOTONIC = 4  # actually CLOCK_MONOTONIC_RAW see <linux/time.h>
 
     try:
-        class _TimeSpec(ctypes.Structure):
-            _fields_ = [
-                ('tv_sec', ctypes.c_long),
-                ('tv_nsec', ctypes.c_long)
-            ]
-
-        _librt = ctypes.CDLL('librt.so.1', use_errno=True)
-        _clock_gettime = _librt.clock_gettime
-        _clock_gettime.argtypes = [ctypes.c_int, ctypes.POINTER(_TimeSpec)]
-
-        def get_time():
-            """Get high-resolution monotonic time stamp (float) """
-            t = _TimeSpec()
-            if _clock_gettime(_CLOCK_MONOTONIC, ctypes.pointer(t)) != 0:
-                errno_ = ctypes.get_errno()
-                raise OSError(errno_, os.strerror(errno_))
-            return t.tv_sec + t.tv_nsec * 1e-9
-        get_time()
+        import ctypes
     except:
-        _use_time_module = True
+        ctypes = None  # Does not exist on Android
+    import os
+    from sys import platform
 
-elif platform == 'win32':
-    # win32. Code adapted from the psychopy.core.clock source code.
-    try:
-        _fcounter = ctypes.c_int64()
-        _qpfreq = ctypes.c_int64()
-        ctypes.windll.Kernel32.QueryPerformanceFrequency(ctypes.byref(_qpfreq))
-        _qpfreq = float(_qpfreq.value)
-        _winQPC = ctypes.windll.Kernel32.QueryPerformanceCounter
+    _fallback_time_module = False
 
-        def get_time():
-            """Get high-resolution monotonic time stamp (float) """
-            _winQPC(ctypes.byref(_fcounter))
-            return  _fcounter.value / _qpfreq
-        get_time()
-    except:
-        _use_time_module = True
-else:
-    # Android or something else
-    _use_time_module = True
+    if platform == 'darwin':
+        # MAC
+        try:
+            class _TimeBase(ctypes.Structure):
+                _fields_ = [
+                    ('numer', ctypes.c_uint),
+                    ('denom', ctypes.c_uint)
+                ]
+
+            _libsys_c = ctypes.CDLL('/usr/lib/system/libsystem_c.dylib')
+            _libsys_kernel = ctypes.CDLL('/usr/lib/system/libsystem_kernel.dylib')
+            _mac_abs_time = _libsys_c.mach_absolute_time
+            _mac_timebase_info = _libsys_kernel.mach_timebase_info
+            _time_base = _TimeBase()
+            if (_mac_timebase_info(ctypes.pointer(_time_base)) != 0):
+                _fallback_time_module = True
+
+            def get_time():
+                """Get high-resolution monotonic time stamp (float) """
+                _mac_abs_time.restype = ctypes.c_ulonglong
+                return float(_mac_abs_time()) * _time_base.numer / (_time_base.denom * 1e9)
+            get_time()
+        except:
+            _fallback_time_module = True
+
+    elif platform.startswith('linux'):
+        # real OS
+        _CLOCK_MONOTONIC = 4  # actually CLOCK_MONOTONIC_RAW see <linux/time.h>
+
+        try:
+            class _TimeSpec(ctypes.Structure):
+                _fields_ = [
+                    ('tv_sec', ctypes.c_long),
+                    ('tv_nsec', ctypes.c_long)
+                ]
+
+            _librt = ctypes.CDLL('librt.so.1', use_errno=True)
+            _clock_gettime = _librt.clock_gettime
+            _clock_gettime.argtypes = [ctypes.c_int, ctypes.POINTER(_TimeSpec)]
+
+            def get_time():
+                """Get high-resolution monotonic time stamp (float) """
+                t = _TimeSpec()
+                if _clock_gettime(_CLOCK_MONOTONIC, ctypes.pointer(t)) != 0:
+                    errno_ = ctypes.get_errno()
+                    raise OSError(errno_, os.strerror(errno_))
+                return t.tv_sec + t.tv_nsec * 1e-9
+            get_time()
+        except:
+            _fallback_time_module = True
+
+    elif platform == 'win32':
+        # win32. Code adapted from the psychopy.core.clock source code.
+        try:
+            _fcounter = ctypes.c_int64()
+            _qpfreq = ctypes.c_int64()
+            ctypes.windll.Kernel32.QueryPerformanceFrequency(ctypes.byref(_qpfreq))
+            _qpfreq = float(_qpfreq.value)
+            _winQPC = ctypes.windll.Kernel32.QueryPerformanceCounter
+
+            def get_time():
+                """Get high-resolution monotonic time stamp (float) """
+                _winQPC(ctypes.byref(_fcounter))
+                return  _fcounter.value / _qpfreq
+            get_time()
+        except:
+            _fallback_time_module = True
+    else:
+        # Android or something else
+        _fallback_time_module = True
 
 
-if _use_time_module:
-    import time
-    try:
-        from time import perf_counter
-    except:
-        perf_counter = None
-
-    if perf_counter is None:
+    if _fallback_time_module:
+        import time
         if platform == 'win32':
             timer_used = "clock"
             def get_time():
@@ -120,11 +125,6 @@ if _use_time_module:
                 """Get high-resolution time stamp (float) """
                 return time.time()
 
-    else:
-        timer_used = "perf_counter"
-        def get_time():
-            """Get high-resolution time stamp (float) """
-            return time.perf_counter()
-
-    print("Warning: Failed to initialize monotonic timer. Python's "
-                         "time.{}() function will be use.".format(timer_used))
+        print("Warning: Failed to initialize monotonic timer. Python's "
+                             "time.{}() function will be used.".format(
+                        timer_used))

--- a/expyriment/misc/_timer.py
+++ b/expyriment/misc/_timer.py
@@ -24,7 +24,7 @@ try:
     from time import perf_counter
     def get_time():
         """Get high-resolution time stamp (float) """
-        return time.perf_counter()
+        return perf_counter()
 
     get_time()
 


### PR DESCRIPTION
`perf_counter` is now fallback function for PY3.3+ under all OS. But the question is whether we need our own timer module at all, if  perf_counter exist? 