### PR TITLE
Two minor bugfixes

### DIFF
--- a/expyriment/__init__.py
+++ b/expyriment/__init__.py
@@ -52,7 +52,7 @@ try:
     import os
     os.environ['PYGAME_HIDE_SUPPORT_PROMPT'] = "hide"
     import pygame as _pygame
-    if _pygame.vernum < (2, 0, 0):
+    if _pygame.vernum < (1, 9, 0):
         raise RuntimeError("Expyriment {0} ".format(__version__) +
                       "is not compatible with Pygame {0}.{1}.{2}.".format(
                           _pygame.vernum[0], _pygame.vernum[1],
@@ -114,4 +114,3 @@ if _internals.get_plugins_folder() is not None:
 
 # post import hook
 exec(_internals.post_import_hook())
-

--- a/expyriment/io/_screen.py
+++ b/expyriment/io/_screen.py
@@ -118,6 +118,10 @@ OpenGL will be deactivated!"
             ogl_version = ogl.glGetString(ogl.GL_VERSION)
             if float(ogl_version[0:3]) < 2.0:
                 ogl_extensions = ogl.glGetString(ogl.GL_EXTENSIONS)
+                if hasattr(ogl_extensions, 'decode'):
+                    # In case a bytes object is returned, which doesn't allow
+                    # for comparison with str objects. Applies to Python 3.
+                    ogl_extensions = ogl_extensions.decode()
                 if "ARB_texture_non_power_of_two" not in ogl_extensions:
                     raise RuntimeError("OpenGL mode is not supported on this \
 machine!")

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ source_files = ['.release_info',
                 'Makefile',
                 'README.md']
 
-install_requires = ["pygame>=2,<3",
+install_requires = ["pygame>=1.9",
                     "pyopengl>=3.0,<4"]
 
 extras_require = {


### PR DESCRIPTION
As I was trying version 0.10.0 on a clean Python 3.7 installation, I ran into the following two bugs. I suspect that both are due to interactions with other changed versions (otherwise they would've been noticed before).

- The PyGame check assumed >= 2, whereas the latest version of PyGame is 1.9.6
- The OpenGL Extension check failed because of a `str` / `bytes` mismatch