### PR TITLE
No key specified to end pause period

### DIFF
--- a/expyriment/control/_experiment_control.py
+++ b/expyriment/control/_experiment_control.py
@@ -246,7 +246,7 @@ def pause():
     stimuli._stimulus.Stimulus._id_counter -= 1
     misc.Clock().wait(200)
     if android is None:
-        experiment.keyboard.wait()
+        experiment.keyboard.wait(keys=[misc.constants.K_RETURN])
     else:
         experiment.mouse.wait_press()
     experiment._event_file_log("Experiment,resumed")


### PR DESCRIPTION
`pause()` function should wait for ENTER to be pressed to continue. Instead, it currently takes any key as an input and so it automatically continues when it receives the TTL pulse.