### PR TITLE
Typos found by codespell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -36,7 +36,7 @@ New Features:
 - ``io.SerialPort`` has a new method ``send_line``
 - geometry module has convenience functions for predefined geometrical
   shapes used for plotting with ``stimuli.Shape``
-- ``geometry.lines_intersection_point`` calculates interscetion point of two
+- ``geometry.lines_intersection_point`` calculates intersection point of two
   lines
 - ``stimuli.Line`` is internally based on ``stimuli.Shape`` and has the new
   methods ``get_shape`` and ``get_connected_shape``
@@ -120,7 +120,7 @@ New Features:
 - randomize.rand_norm() normally distributed random numbers
 - statistics module: std & variance
 - Eventfile.log has an optional log_event_tag for the logging of
-  inter-event-intervalls. If this is defined a summary of the intervalls
+  inter-event-intervals. If this is defined a summary of the intervals
   will be added to the event file.
 - All present methods have an optional log_event_tag that will be passed
   to Eventfile.log (see above)
@@ -482,7 +482,7 @@ Fixed:
 - major bug in keyboard.check()
 - (possibly) fixed is_playing() method in Audio
 - ordering of serial ports in SerialPort.get_available_ports()
-- visual problems when graphics card is set to do flipping with tripple buffer
+- visual problems when graphics card is set to do flipping with triple buffer
 
 Version 0.4.0 (22 Nov 2011)
 ---------------------------

--- a/documentation/sphinx/DataPreprocessing.rst
+++ b/documentation/sphinx/DataPreprocessing.rst
@@ -19,7 +19,7 @@ CSV format
 ~~~~~~~~~~
 The method ``misc.data_preprocessing.write_concatenated_data()`` in
 :doc:`Data Preprocessing <expyriment.misc.data_preprocessing>`
-allows to export the concatenated data as a CSV (comman separated values) file.
+allows to export the concatenated data as a CSV (comma separated values) file.
 
 R data frame
 ~~~~~~~~~~~~

--- a/documentation/sphinx/Overview.rst
+++ b/documentation/sphinx/Overview.rst
@@ -133,7 +133,7 @@ The new official Expyriment support forum can be found at http://forum.expyrimen
 
 Matrix/IRC channel
 ------------------
-To ask questions or to have real-time discussions with other users and the developers you can also use our `Matrix chat <https://riot.im/app/#/room/#expyriment:matrix.org>`_. The room is also accesible from IRC::
+To ask questions or to have real-time discussions with other users and the developers you can also use our `Matrix chat <https://riot.im/app/#/room/#expyriment:matrix.org>`_. The room is also accessible from IRC::
 
     Server: irc.freenode.org
     Channel: #expyriment

--- a/documentation/sphinx/Problems.rst
+++ b/documentation/sphinx/Problems.rst
@@ -9,7 +9,7 @@ No native 3D stimuli
 --------------------
 Right now Expyriment only offers static 2D visual stimuli.
 
-While PyOpenGL can be used direclty to create dynamic 3D stimuli, we are 
+While PyOpenGL can be used directly to create dynamic 3D stimuli, we are 
 planning to add a dedicated 3D stimulus class in the future, to facilitate the 
 creation of 3D stimuli.
 

--- a/documentation/sphinx/Testsuite.rst
+++ b/documentation/sphinx/Testsuite.rst
@@ -48,7 +48,7 @@ Here is a brief explanation of the available options:
     screen; if two buffers (double buffer) are used, new stimuli will be drawn to
     an additional page, and a screen update will replace the screen with this page
     and put the screen contents into the page (i.e. the two buffers are swapped);
-    if three buffers (tripple buffer) are used, new stimuli will be drawn to a third
+    if three buffers (triple buffer) are used, new stimuli will be drawn to a third
     page, and a screen update will replace the screen with this page, and put the
     screen contents into the second page (i.e. a history of 2 former screens is
     kept)

--- a/documentation/sphinx/Tutorial.rst
+++ b/documentation/sphinx/Tutorial.rst
@@ -408,7 +408,7 @@ Let's see why this is:
     directory where your first_example.py is located). The "data" directory 
     contains data log files, named according to the experiment name, the 
     subject number and a timestamp. The file ending is .xpd. (Note: To 
-    disable time stamps in output filenames, you have change the defauls of
+    disable time stamps in output filenames, you have change the defaults of
     the io module before you initialize your experiment: 
     ``expyriment.io.defaults.outputfile_time_stamp = False``).  The event 
     directory contains event log files with the ending .xpe.

--- a/documentation/sphinx/Unicode.rst
+++ b/documentation/sphinx/Unicode.rst
@@ -10,7 +10,7 @@ Non-English characters in strings in the Expyriment script file
 When attempting to use non-English characters in strings in your Expyriment
 script file, the following three conditions have to be met:
 
-1. **Only use non-English charactes in unicode strings (Python 2 only)!**
+1. **Only use non-English characters in unicode strings (Python 2 only)!**
    For example: Use ``u"Überexperiment"`` instead of ``"Überexperiment"``.
    (In Python 3 you can use normal strings, as they are already unicode compatible.)
 

--- a/expyriment/control/_experiment_control.py
+++ b/expyriment/control/_experiment_control.py
@@ -181,7 +181,7 @@ def start(experiment=None, auto_create_subject_id=None, subject_id=None,
         stimuli._stimulus.Stimulus._id_counter -= 1
         text.present()
         text.present()  # for flipping with double buffer
-        text.present()  # for flipping with tripple buffer
+        text.present()  # for flipping with triple buffer
     default_textline_size = stimuli.TextLine(text="").text_size
     while number > 0:
         counter = stimuli.TextLine(

--- a/expyriment/control/_test_suite.py
+++ b/expyriment/control/_test_suite.py
@@ -311,7 +311,7 @@ After the test, you will be asked to indicate which (if any) of those two square
 #         info = """This will test the video card's settings for multiple buffers and page flipping.
 # If none of the following squares are constantly blinking, page flipping is not activated and buffer contents are copied.
 # If only the left square is constantly blinking, page flipping is activated and a double buffer is used.
-# If additionally the right square is constantly blinking, page flipping is activated and a tripple buffer is used.
+# If additionally the right square is constantly blinking, page flipping is activated and a triple buffer is used.
 #
 # [Press RETURN to continue]"""
 #

--- a/expyriment/io/_files.py
+++ b/expyriment/io/_files.py
@@ -672,7 +672,7 @@ class EventFile(OutputFile):
             the event to be logged (anything, will be casted to str)
         log_event_tag : numeral or string, optional
             if log_event_tag is defined, event file logs the inter-event-intervalls
-            and adds a summary of the intervalls at the end of the file
+            and adds a summary of the intervals at the end of the file
 
         Returns
         -------
@@ -703,7 +703,7 @@ class EventFile(OutputFile):
         self.write_line(line)
 
     def _write_inter_event_intervall_summary(self):
-        """appending the inter event intervall summary to event file, if log_event_tag have been set while presentation
+        """appending the inter event interval summary to event file, if log_event_tag have been set while presentation
         this function will be called at exit"""
 
         for l in self._inter_event_intervall_log.summary():
@@ -712,7 +712,7 @@ class EventFile(OutputFile):
 
 
 class _InterEventIntervallLog():
-    """This class is used to log the intervalls of tagged events to get a
+    """This class is used to log the intervals of tagged events to get a
     summary of the timing at the end of the event file
     """
 
@@ -735,7 +735,7 @@ class _InterEventIntervallLog():
 
 
     def _get_iei_intervalls(self, from_tag, to_tag):
-        """helper function: get the intervalls between two events"""
+        """helper function: get the intervals between two events"""
 
         rtn = []
         try:

--- a/expyriment/io/_mouse.py
+++ b/expyriment/io/_mouse.py
@@ -129,7 +129,7 @@ class Mouse(Input):
         if corner is not None:
             if not isinstance(corner, int) or corner<0 or corner >3:
                 corner = None
-                print("Warning: {} is an unkown corner location. Mouse quit "
+                print("Warning: {} is an unknown corner location. Mouse quit "
                                      "event is deactivated.".format(corner))
         Mouse._quit_corner_location = corner
 
@@ -176,7 +176,7 @@ class Mouse(Input):
             return False
 
         if click_position is None:
-            # check Pygame queu
+            # check Pygame queue
             pos = None
             # pygame.event.pump() # not sure if it is required!
             for event in pygame.event.get(pygame.MOUSEBUTTONDOWN):

--- a/expyriment/io/_textinput.py
+++ b/expyriment/io/_textinput.py
@@ -404,7 +404,7 @@ class TextInput(Input):
         self._canvas.plot(background)
         background.present()
         background.present()  # for flipping with double buffer
-        background.present()  # for flipping with tripple buffer
+        background.present()  # for flipping with triple buffer
 
     def _update(self):
         """Update the input box."""

--- a/expyriment/misc/_get_system_info.py
+++ b/expyriment/misc/_get_system_info.py
@@ -76,7 +76,7 @@ def get_system_info(as_string=False):
         from platform import linux_distribution
     except Exception:
         try:
-            from distro import linux_distribution #TODO: only avaiable for Linux, should it be a suggested package dependency?
+            from distro import linux_distribution #TODO: only available for Linux, should it be a suggested package dependency?
         except Exception:
             def linux_distribution():
                 return ("Linux", "?", "?")

--- a/expyriment/misc/_miscellaneous.py
+++ b/expyriment/misc/_miscellaneous.py
@@ -429,7 +429,7 @@ def which(programme):
 def download_from_stash(content="all", branch=None):
     """Download content from the Expyriment stash.
 
-    Content will be stored in an Expyriment settings diretory (`.expyriment`
+    Content will be stored in an Expyriment settings directory (`.expyriment`
     or `~expyriment`, located in the current user's home directory).
 
     Parameters

--- a/expyriment/misc/geometry/_geometry.py
+++ b/expyriment/misc/geometry/_geometry.py
@@ -61,7 +61,7 @@ def position2coordinates(position, surface_size=None):
         position (x,y) to convert
     surface_size: (int, int), optional
         size of the surface one which coordinates should be calculated
-        if None (default), the coordinats will be calculated relative
+        if None (default), the coordinates will be calculated relative
         to the screen
 
     Returns
@@ -295,7 +295,7 @@ class XYPoint(object):
 
         Notes
         -----
-        use `x`, `y` values (two numberic) or the tuple xy=(x,y)
+        use `x`, `y` values (two numbers) or the tuple xy=(x,y)
 
         """
 
@@ -370,7 +370,7 @@ class XYPoint(object):
         return self
 
     def distance(self, p):
-        """Return euclidian distance to the points (p).
+        """Return euclidean distance to the points (p).
 
         Parameters
         ----------

--- a/expyriment/stimuli/_circle.py
+++ b/expyriment/stimuli/_circle.py
@@ -34,7 +34,7 @@ class Circle(Ellipse):
         colour : (int,int,int), optional
             colour of the circle
         line_width : int, optional
-            line width in pixels betwee >= 0 and < radius,
+            line width in pixels between >= 0 and < radius,
             0 will result in a filled circle
         position : (int, int), optional
             position of the stimulus

--- a/expyriment/stimuli/_line.py
+++ b/expyriment/stimuli/_line.py
@@ -284,7 +284,7 @@ class Line(Visual):
                                                               b_long_edge[0], b_long_edge[1])
                 if sharp_corner_point is not None:
                     a_modified.insert(id_insert, sharp_corner_point)
-                    id_insert +=1 # because it is later used to determin the join point
+                    id_insert +=1 # because it is later used to determine the join point
             rtn = Shape(colour=line_shape_a.colour,
                         anti_aliasing=line_shape_a.anti_aliasing,
                         vertex_list=tuple(points2vertices(a_modified)))

--- a/expyriment/stimuli/_shape.py
+++ b/expyriment/stimuli/_shape.py
@@ -128,7 +128,7 @@ class Shape(Visual):
             list of vertices (int, int)
         debug_contour_colour : (int, int, int), optional
             The colour of the contour of the shape.
-            If None (default), contour colour is not displyed.
+            If None (default), contour colour is not displayed.
             Use this option only for debugging. The resulting surface size
             might be enlarged by one pixel large depending on the shape.
 

--- a/expyriment/stimuli/_visual.py
+++ b/expyriment/stimuli/_visual.py
@@ -310,7 +310,7 @@ class Visual(Stimulus):
         Notes
         -----
         The absolute position differs for instance from the (relative) position, if the
-        stimulus is plotted ontop of another stimulus, which has not the position (0,0).
+        stimulus is plotted on top of another stimulus, which has not the position (0,0).
 
         """
 
@@ -976,7 +976,7 @@ class Visual(Stimulus):
         stimululs is written to.
         The surface will now be read from the disk to free memory.
         Compressed stimuli cannot do surface operations!
-        Preloading comressed stimuli is possible and highly recommended.
+        Preloading compressed stimuli is possible and highly recommended.
         Depending on the size of the stimulus, this method may take some time
         to compute!
 
@@ -1452,7 +1452,7 @@ class Visual(Stimulus):
         self.scale((level, level))
         if self._logging:
             _internals.active_exp._event_file_log(
-                "Stimulus,blured,{0}, level={1}".format(self.id, level), 2)
+                "Stimulus,blurred,{0}, level={1}".format(self.id, level), 2)
         return int((get_time() - start) * 1000)
 
     def scramble(self, grain_size):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,_fonts
+ignore-words-list = ans,hist,numer,ro,ser

--- a/setup.py
+++ b/setup.py
@@ -82,6 +82,7 @@ extras_require = {
                            "pyparallel>=0.2,<1",
                            "sounddevice>=0.3,<1",
                            "mediadecoder>=0.1,<1"],
+    'dev':                ["codespell"],
     }
 
 entry_points = {


### PR DESCRIPTION
I've limited this merge request to documentation: `*.md` files and `documentation` directory.

Would you be willing to accept fixes for other typos? There remain ~100 of them but most are false positives or 3rd party files. Please note it's easier to fix both code comments for developers and user-visible text.

I could also add a `setup.cfg` file so that developers can easily run [codespell](https://github.com/codespell-project/codespell) and fix typos as they modify files.