### PR TITLE
Design factor names: sort when casting set to list

### DIFF
--- a/expyriment/design/_structure.py
+++ b/expyriment/design/_structure.py
@@ -775,7 +775,7 @@ type".format(permutation_type))
         factors = []
         for bl in self.blocks:
             factors.extend(bl.trial_factor_names)
-        return list(set(factors))
+        return sorted(set(factors))
 
     @property
     def block_list_factor_names(self):
@@ -788,7 +788,7 @@ type".format(permutation_type))
         factors = []
         for bl in self.blocks:
             factors.extend(bl.factor_names)
-        return list(set(factors))
+        return sorted(set(factors))
 
     @property
     def design_as_text(self):


### PR DESCRIPTION
Currently, when printing or saving designs, the block and trial factors will be differently ordered for every Python session. This is because sets don't have an order and when being casted to lists the assigned order seems to be random. I think we should explicitly order those factor names, such that the resulting design CSV file is better readable.