### PR TITLE
io.keyboard: low_performance wait

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@ Changed:
 - pause_key has been removed 
 - test suite: improved audio test
 - rewrite permutation module
+- io.Keyboard.wait and io.Keyboard.wait_char: added parameter `low_performance`
+- io.GamePad.wait_press: removed `time.sleep(0.0005)`
 
 Fixed:
 - bug in colour.is_hex & colour.is_colour

--- a/expyriment/io/_gamepad.py
+++ b/expyriment/io/_gamepad.py
@@ -288,8 +288,6 @@ class GamePad(Input, Output):
                         done = True
                         break
 
-            time.sleep(0.0005)
-
         if self._logging:
             _internals.active_exp._event_file_log(
                             "Gamepad,received,{0},wait_press".format(_button))

--- a/expyriment/io/_keyboard.py
+++ b/expyriment/io/_keyboard.py
@@ -214,7 +214,8 @@ class Keyboard(Input):
         return None
 
     def wait(self, keys=None, duration=None, wait_for_keyup=False,
-             callback_function=None, process_control_events=True):
+             callback_function=None, process_control_events=True,
+             low_performance=False):
         """Wait for keypress(es) (optionally for a certain amount of time).
 
         This function will wait for a keypress and returns the found key as
@@ -234,6 +235,9 @@ class Keyboard(Input):
         process_control_events : bool, optional
             process ``io.Keyboard.process_control_keys()`` and
             ``io.Mouse.process_quit_event()`` (default = True)
+        low_performance : bool, optional
+            reduce CPU performance while waiting at the cost of less timing
+            accuracy (default = False)
 
         Returns
         -------
@@ -306,7 +310,7 @@ class Keyboard(Input):
                         done = True
             if duration and not done:
                 done = int((get_time() - start) * 1000) >= duration
-            if not done:
+            if not done and low_performance:
                 time.sleep(0.0005)
         if self._logging:
             _internals.active_exp._event_file_log("Keyboard,received,{0},wait"\
@@ -316,7 +320,7 @@ class Keyboard(Input):
         return found_key, rt
 
     def wait_char(self, char, duration=None, callback_function=None,
-                  process_control_events=True):
+                  process_control_events=True, low_performance=False):
         """Wait for character(s) (optionally for a certain amount of time).
 
         This function will wait for one or more characters and returns the
@@ -334,6 +338,9 @@ class Keyboard(Input):
         process_control_events : bool, optional
             process ``io.Keyboard.process_control_keys()`` and
             ``io.Mouse.process_quit_event()`` (default = True)
+        low_performance : bool, optional
+            reduce CPU performance while waiting at the cost of less timing
+            accuracy (default = False)
 
         Returns
         -------
@@ -389,7 +396,7 @@ class Keyboard(Input):
                         done = True
             if duration and not done:
                 done = int((get_time() - start) * 1000) >= duration
-            if not done:
+            if not done and low_performance:
                 time.sleep(0.0005)
         if self._logging:
             if found_char is not None:


### PR DESCRIPTION
* Added `low_performance` parameter to io.Keyboard.wait and io.Keyboard.wait_char (default=False)
* Removed `time.sleep(0.0005)` from io.GamePad.wait_press