### PR TITLE
Audio and Video improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,6 +54,17 @@ Changed:
     - all arguments are now also available as alternative long names
 - io.TextMenu: `width` is now an optional parameter. If not defined, surface width is based on the widest item in the menu
 - misc.get_system_info: format changes for ``as_text`` output and improvements
+- audiosystem:
+    - support for selecting audio device
+    - new control default ``audiosystem_device``
+    - new function ``misc.get_audio_devices``
+- stimuli.Video:
+    - general improvements
+    - Pygame video backend removed (always relies on mediadecoder)
+    - Pygame audio backend is now the default (instead of sounddevice)
+    - new parameter ``audio_backend``
+    - new stimuli default ``video_audio_backend``
+    - Pygame audio backend uses current audiosystem (if started)
 
 Fixed:
 - bug in colour.is_hex & colour.is_colour

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -45,19 +45,24 @@ Changed:
 - Deprecated io.Screen.get_monitor_resolution and misc.get_monitor_resolution
 - Always use maximal display resolution by default for fullscreen mode (unless
   overwritten by control.defaults.display_resolution)
-- ``expyriment.control.defaults.openg_gl`` is now called ``expyriment.control.defaults.opengl``
+- ``expyriment.control.defaults.openg_gl`` is now called
+  ``expyriment.control.defaults.opengl``
 - OpenGL mode "3" has been removed: OpenGL mode "2" (default) now does what
   "3" used to do (i.e. "alternative blocking")
 - updated command line interface options:
     - ``-0``, ``-g``, ``--no-opengl``, ``-1``, ``-2``, ``-3`` are depreated
     - OpenGL mode can now be set with new option ``--opengl``
     - all arguments are now also available as alternative long names
-- io.TextMenu: `width` is now an optional parameter. If not defined, surface width is based on the widest item in the menu
+- io.TextMenu: `width` is now an optional parameter. If not defined, surface
+  width is based on the widest item in the menu
 - misc.get_system_info: format changes for ``as_text`` output and improvements
 - audiosystem:
     - support for selecting audio device
     - new control default ``audiosystem_device``
     - new function ``misc.get_audio_devices``
+- stimuli.Audio:
+    - not limited to .wav/.ogg files anymore
+    - should support most common formats (i.e. WAV, AIFF, MP3, Ogg, Opus, FLAC)
 - stimuli.Video:
     - general improvements
     - Pygame video backend removed (always relies on mediadecoder)

--- a/expyriment/__init__.py
+++ b/expyriment/__init__.py
@@ -90,9 +90,9 @@ try:
 
 except ImportError:
     print("No OpenGL support!" +
-                    "\nExpyriment {0} ".format(__version__) +
-                      "needs the package 'PyOpenGL'."
-                      "\nPlease install PyOpenGL(>=3,<4) for OpenGL functionality.")
+          "\nExpyriment {0} ".format(__version__) +
+          "needs the package 'PyOpenGL'."
+          "\nPlease install PyOpenGL(>=3,<4) for OpenGL functionality.")
 
 
 from ._internals import get_version, import_all_extras

--- a/expyriment/_internals.py
+++ b/expyriment/_internals.py
@@ -9,16 +9,13 @@ from builtins import object
 __author__ = 'Florian Krause <florian@expyriment.org> \
 Oliver Lindemann <oliver@expyriment.org>'
 
-import sys
 import os
+import sys
+
 import pygame
 
-try:
-    import android
-except ImportError:
-    android = None
-
 from . import __version__
+
 
 def get_version():
     """
@@ -158,9 +155,10 @@ def get_settings_folder():
 
     home = os.getenv('USERPROFILE')
     if home is None:
-        if android is not None:
+        try:
+            sys.getandroidapilevel()
             home = "/storage/sdcard0/"
-        else:
+        except AttributeError:
             home = os.getenv('HOME')
     if is_venv():
         home = sys.prefix

--- a/expyriment/control/_experiment_control.py
+++ b/expyriment/control/_experiment_control.py
@@ -427,7 +427,8 @@ fullscreen.""")
     mixer.pre_init(defaults.audiosystem_sample_rate,
                    defaults.audiosystem_bit_depth,
                    defaults.audiosystem_channels,
-                   defaults.audiosystem_buffer_size)
+                   defaults.audiosystem_buffer_size,
+                   devicename=defaults.audiosystem.device)
     if defaults.audiosystem_autostart:
         mixer.init()
         mixer.init()  # Needed on some systems

--- a/expyriment/control/_experiment_control.py
+++ b/expyriment/control/_experiment_control.py
@@ -428,7 +428,7 @@ fullscreen.""")
                    defaults.audiosystem_bit_depth,
                    defaults.audiosystem_channels,
                    defaults.audiosystem_buffer_size,
-                   devicename=defaults.audiosystem.device)
+                   devicename=defaults.audiosystem_device)
     if defaults.audiosystem_autostart:
         mixer.init()
         mixer.init()  # Needed on some systems

--- a/expyriment/control/_experiment_control.py
+++ b/expyriment/control/_experiment_control.py
@@ -12,8 +12,9 @@ import pygame
 
 from . import defaults
 from ._miscellaneous import _set_stdout_logging, start_audiosystem
-from .._internals import get_version, android
+from .._internals import get_version
 from .. import design, stimuli, misc, _internals
+from ..misc import is_android_running
 from ..io import DataFile, EventFile, TextInput, Keyboard, Mouse, \
                 _keyboard, TouchScreenButtonBox
 from ..io._screen import Screen
@@ -81,7 +82,7 @@ def start(experiment=None, auto_create_subject_id=None, subject_id=None,
         default_number = subject_id
 
     if not auto_create_subject_id:
-        if android is not None:
+        if is_android_running():
             background_stimulus = stimuli.BlankScreen(colour=(0, 0, 0))
             fields = [stimuli.Circle(radius=100, colour=(70, 70, 70),
                                      position=(0, 70), anti_aliasing=10),
@@ -200,7 +201,7 @@ def start(experiment=None, auto_create_subject_id=None, subject_id=None,
                          text_size=int(experiment.text_size * 1.2),
                          text_colour=misc.constants.C_EXPYRIMENT_ORANGE).present()
         stimuli._stimulus.Stimulus._id_counter -= 1
-        if android is None:
+        if is_android_running():
             experiment.keyboard.wait()
         else:
             experiment.mouse.wait_press()
@@ -236,7 +237,7 @@ def pause(text="Paused", key=misc.constants.K_RETURN):
     experiment._screen.colour = [0, 0, 0]
     old_logging = experiment.log_level
     experiment.set_log_level(0)
-    if android is not None:
+    if is_android_running():
         position = (0, 200)
     else:
         position = (0, 0)
@@ -248,7 +249,7 @@ def pause(text="Paused", key=misc.constants.K_RETURN):
     experiment._screen.colour = screen_colour
     stimuli._stimulus.Stimulus._id_counter -= 1
     misc.Clock().wait(200)
-    if android is None:
+    if is_android_running():
         experiment.keyboard.wait(keys=(key))
     else:
         experiment.mouse.wait_press()
@@ -303,7 +304,7 @@ def end(goodbye_text=None, goodbye_delay=None, confirmation=False,
         experiment._event_file_log("Experiment,paused")
         screen_colour = experiment.screen.colour
         experiment._screen.colour = [0, 0, 0]
-        if android is not None:
+        if is_android_running():
             position = (0, 200)
         else:
             position = (0, 0)

--- a/expyriment/control/_experiment_control.py
+++ b/expyriment/control/_experiment_control.py
@@ -9,13 +9,9 @@ Oliver Lindemann <oliver@expyriment.org>'
 import sys
 import os
 import pygame
-try:
-    import android.mixer as mixer
-except ImportError:
-    import pygame.mixer as mixer
 
 from . import defaults
-from ._miscellaneous import _set_stdout_logging
+from ._miscellaneous import _set_stdout_logging, start_audiosystem
 from .._internals import get_version, android
 from .. import design, stimuli, misc, _internals
 from ..io import DataFile, EventFile, TextInput, Keyboard, Mouse, \
@@ -424,14 +420,21 @@ fullscreen.""")
     _keyboard.quit_key = defaults.quit_key
     _keyboard.end_function = end
 
-    mixer.pre_init(defaults.audiosystem_sample_rate,
-                   defaults.audiosystem_bit_depth,
-                   defaults.audiosystem_channels,
-                   defaults.audiosystem_buffer_size,
-                   devicename=defaults.audiosystem_device)
+    if defaults.audiosystem_bit_depth not in (8, -8, 16, -16, 32):
+        message = "Audiosystem only supports bit depth values of " + \
+            "8, -8, 16, -16 and 32."
+        raise RuntimeError(message.format(defaults.audiosystem.bit_depth))
+    if defaults.audiosystem_channels not in (1, 2, 4, 6):
+        message = "Audiosystem only supports channel values of 1, 2, 4 and 6."
+        raise RuntimeError(message.format(defaults.audiosystem.channels))
+    pygame.mixer.pre_init(defaults.audiosystem_sample_rate,
+                          defaults.audiosystem_bit_depth,
+                          defaults.audiosystem_channels,
+                          defaults.audiosystem_buffer_size,
+                          devicename=defaults.audiosystem_device,
+                          allowedchanges=0)
     if defaults.audiosystem_autostart:
-        mixer.init()
-        mixer.init()  # Needed on some systems
+        start_audiosystem()
 
     experiment._clock = misc.Clock()
     if hasattr(defaults, "open_gl"):

--- a/expyriment/control/_miscellaneous.py
+++ b/expyriment/control/_miscellaneous.py
@@ -27,7 +27,12 @@ def start_audiosystem():
 
     """
 
-    pygame.mixer.init()
+    try:
+        pygame.mixer.init()
+        pygame.mixer.init()  # needed on some systems
+    except:
+        message = "Audiosystem could not be initialized with given parameters."
+        raise RuntimeError(message)
 
 
 def stop_audiosystem():

--- a/expyriment/control/_test_suite.py
+++ b/expyriment/control/_test_suite.py
@@ -237,9 +237,9 @@ After the test, you will be asked to indicate which (if any) of those two square
             text_font="freemono", text_size=int(16 * scaling), text_bold=True,
             text_justification=0, text_colour=results2_colour,
             position=(0, int(20 * scaling)))
-        if inaccuracy > 2:
+        if inaccuracy > round(refresh_rate / 4):
             results3_colour = [255, 0, 0]
-        elif inaccuracy in (1, 2):
+        elif 0 < inaccuracy <= round(refresh_rate / 4):
             results3_colour = [255, 255, 0]
         else:
             results3_colour = [0, 255, 0]

--- a/expyriment/control/_test_suite.py
+++ b/expyriment/control/_test_suite.py
@@ -17,7 +17,7 @@ try:
 except Exception:
     ogl = None
 
-from . import defaults, initialize, end
+from . import defaults, initialize, end, start_audiosystem, stop_audiosystem
 from .. import stimuli, io, _internals, design, control
 import expyriment
 
@@ -466,11 +466,10 @@ Afterwards, a test tone will be played back to you with the chosen settings.
 
     # Test if audio format is supported
     try:
-        pygame.mixer.quit()
+        stop_audiosystem()
         pygame.mixer.pre_init(audio_format[0], audio_format[1][0],
-                              audio_format[2])
-        pygame.mixer.init()
-        pygame.mixer.init()
+                              audio_format[2], allowedchanges=0)
+        start_audiosystem()
     except:
         info = f"""'{audio_device}' does not support '{audio_format[0]} Hz, {audio_format[1][1]}, {audio_format[2]} {ch}'.
 
@@ -758,11 +757,9 @@ def run_test_suite(item=None):
     v.plot(background)
     results = get_system_info()
 
-    try:
-        import android
+    if misc.is_android_running():
         mouse = io.Mouse(show_cursor=False)
-    except ImportError:
-        android = None
+    else:
         mouse = None
 
     preselected_item = 0

--- a/expyriment/control/_test_suite.py
+++ b/expyriment/control/_test_suite.py
@@ -381,7 +381,8 @@ def _audio_playback(exp):
     """Test the audio playback"""
 
     info = f"""This will test the auditory stimulus presentation capabilities of your system.
-You will be asked to select the audio device, format, and buffer size to test. Afterwards, a test tone will be played back to you with the chosen settings.
+You will be asked to select the audio device, format, and buffer size to test.
+Afterwards, a test tone will be played back to you with the chosen settings.
 
 [Press RETURN to continue]
 """
@@ -459,6 +460,31 @@ You will be asked to select the audio device, format, and buffer size to test. A
                            menu_items=[f"{x}" for x in channel_counts])
         audio_format.append(channel_counts[menu.get(index)])
 
+    ch = "channel"
+    if audio_format[2] > 1:
+        ch += "s"
+
+    # Test if audio format is supported
+    try:
+        pygame.mixer.quit()
+        pygame.mixer.pre_init(audio_format[0], audio_format[1][0],
+                              audio_format[2])
+        pygame.mixer.init()
+        pygame.mixer.init()
+    except:
+        info = f"""'{audio_device}' does not support '{audio_format[0]} Hz, {audio_format[1][1]}, {audio_format[2]} {ch}'.
+
+[Press RETURN to continue]
+        """
+        text = stimuli.TextScreen(f"Audio format not supported", info)
+        while True:
+            text.present()
+            key, rt_ = exp.keyboard.wait([constants.K_RETURN])
+            if key is not None:
+                break
+            return
+        return "", ""
+
     # Get buffer size
     options = [f"{x}" for x in buffer_sizes]
     default = control.defaults.audiosystem_buffer_size
@@ -469,23 +495,7 @@ You will be asked to select the audio device, format, and buffer size to test. A
     menu = io.TextMenu("Buffer size", menu_items=options)
     buffer_size = buffer_sizes[menu.get(index)]
 
-    ch = "channel"
-    if audio_format[2] > 1:
-        ch += "s"
-    settings = \
-        f"{audio_format[0]} Hz, {audio_format[1][1]}, {audio_format[2]} {ch}, {buffer_size} samples"
-    pygame.mixer.quit()
-    pygame.mixer.pre_init(audio_format[0], audio_format[1][0], audio_format[2],
-                          buffer_size)
-    pygame.mixer.init()
-    pygame.mixer.init()
-
-    info = f"""A test tone will now be played with the following audio settings:
-
-{audio_device}
-{settings}
-
-Listen carefully to whether you can hear the tone clearly and undistorded.
+    info = f"""A test tone will now be played on '{audio_device}' with format '{audio_format[0]} Hz, {audio_format[1][1]}, {audio_format[2]} {ch}' and a buffer of {buffer_size} samples.
 
 [Press RETURN to continue]
 """

--- a/expyriment/control/_test_suite.py
+++ b/expyriment/control/_test_suite.py
@@ -83,22 +83,10 @@ After the test, you will be asked to indicate which (if any) of those two square
 [Press RETURN to continue]"""
 
         text = stimuli.TextScreen("Visual stimulus presentation test", info)
-        #y = []
-        #for x in [16, 32, 48, 64]:
-        #    y.extend([x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, ])
-        #graph1 = _make_graph(range(60), y, [0, 255, 0])
-        #y = range(80)
-        #graph2 = _make_graph(range(60), y, [255, 0, 0])
-        #graph1.position = (-200, -100)
-        #graph2.position = (200, -100)
-        while True:
-            text.present()
-        #graph1.present(clear=False, update=False)
-        #graph2.present(clear=False)
-            key, rt_ = exp.keyboard.wait([constants.K_RETURN])
-            if key is not None:
-                break
+        text.present()
+        key, rt_ = exp.keyboard.wait([constants.K_RETURN])
         message = stimuli.TextScreen("Running", "Please wait...")
+        message.present()
         message.present()
         message.present()
         message.present()
@@ -121,11 +109,12 @@ After the test, you will be asked to indicate which (if any) of those two square
         c2.present(clear=False)
         c3.present(clear=False)
 
-        s1 = stimuli.Circle(1, colour=exp.background_colour)
-        s2 = stimuli.Circle(1, colour=exp.background_colour)
+        s1 = stimuli.Canvas(exp.screen.size)  # fullscreen transparent
+        s2 = stimuli.Canvas(exp.screen.size)  # fullscreen transparent
         s1.preload()
         s2.preload()
-        to_do_time = list(range(0, 60)) * 3
+        to_do_time = list(range(0,25)) + list(range(100,125)) + \
+                     list(range(200,225)) + list(range(300,325))
         randomize.shuffle_list(to_do_time)
         actual_time = []
         for x in to_do_time:
@@ -136,46 +125,31 @@ After the test, you will be asked to indicate which (if any) of those two square
             actual_time.append((get_time() - start) * 1000)
             exp.clock.wait(randomize.rand_int(30, 60))
 
-        # determine refresh_rate
+        # determine refresh rate
+        s1 = stimuli.Circle(0, colour=exp.background_colour)  # 1 px
+        s2 = stimuli.Circle(0, colour=exp.background_colour)  # 1 px
+        s1.preload()
+        s2.preload()
         tmp = []
-        for _x in range(100):
+        for _x in range(200):
             start = get_time()
             s1.present(clear=False)
             tmp.append(get_time() - start)
             start = get_time()
             s2.present(clear=False)
             tmp.append(get_time() - start)
-        refresh_rate = 1000 / (statistics.mean(tmp) * 1000)
 
-        #text = stimuli.TextScreen("Results", "[Press RETURN to continue]")
-        #graph = _make_graph(to_do_time, actual_time, [150, 150, 150])
-        #graph.position = (0, -100)
-        #text.present(update=False)
-        #graph.present(clear=False)
-        #exp.keyboard.wait([constants.K_RETURN])
-        #text = stimuli.TextScreen(
-        #    "Which picture looks most similar to the results?",
-        #    "[Press LEFT or RIGHT arrow key]")
-        #y = []
-        #for x in [16, 32, 48, 64]:
-        #    y.extend([x, x, x, x, x, x, x, x, x, x, x, x, x, x, x, ])
-        #graph1 = _make_graph(range(60), y, [0, 255, 0])
-        #y = range(80)
-        #graph2 = _make_graph(range(60), y, [255, 0, 0])
-        #graph1.position = (-200, -100)
-        #graph2.position = (200, -100)
-        #text.present(update=False)
-        #graph1.present(clear=False, update=False)
-        #graph2.present(clear=False)
-        #key, _rt = exp.keyboard.wait([constants.K_LEFT,
-        #                             constants.K_RIGHT])
-        #if key == constants.K_LEFT:
-        #    response1 = "Steps"
-        #elif key == constants.K_RIGHT:
-        #    response1 = "Line"
-        #else:
-        #    response1 = None
-
+        # ignore dropped frames and rate limiting
+        tmp1 = []
+        tmp2 = []
+        for c, x in enumerate(tmp[1:]):
+            if c > 0 and x / statistics.mean(tmp1) > 1.5:
+                tmp2.append(x)
+            else:
+                tmp1.append(x)
+        refresh_rate = 1000 / (statistics.mean(tmp1) * 1000)
+        dropped_frames = len(tmp2) / len(tmp1)
+        print(dropped_frames)
 
         def get_local_peak(presentation_time, refresh_rate, spread=25):
             refresh_time = 1000 / refresh_rate
@@ -195,6 +169,9 @@ After the test, you will be asked to indicate which (if any) of those two square
                 return 0
 
         # delay = map(lambda x: x[1]- x[0], zip(to_do_time, actual_time))
+        diff = [x[0] - x[1] for x in zip(actual_time, to_do_time)]
+        print(diff)
+        print(statistics.mean(diff))
         unexplained_delay = [x[1]- x[0] - expected_delay(x[0], refresh_rate) for x in zip(to_do_time, actual_time)]
         hist, hist_str = _histogram(unexplained_delay)
         inaccuracies = []
@@ -208,7 +185,7 @@ After the test, you will be asked to indicate which (if any) of those two square
             if key > 0:
                 delayed_presentations += hist[key]
         inaccuracy = int(misc.round(sum(inaccuracies) / len(inaccuracies)))
-        delayed = misc.round(100 * delayed_presentations/180.0, 1)
+        delayed = misc.round(100 * delayed_presentations/len(to_do_time), 1)
 
         respkeys = {constants.K_F1:0, constants.K_F2:1, constants.K_F3:2,
                     constants.K_0:0, constants.K_1:1, constants.K_2:2}
@@ -236,15 +213,27 @@ After the test, you will be asked to indicate which (if any) of those two square
             results1_colour = [255, 255, 0]
         else:
             results1_colour = [0, 255, 0]
+        r = "{0} Hz (~ every {1} ms)".format(
+            int(misc.round(refresh_rate)),
+            misc.round(1000/refresh_rate, 1))
+        if tmp2 != []:
+            r += " [{0} Hz after {1} frames!]".format(
+                int(misc.round(refresh_rate2)),
+                len(tmp1) + 1)
+            results1_colour = [255, 255, 0]
         results1 = stimuli.TextScreen("",
-                    "Estimated Screen Refresh Rate:     {0} Hz (~ every {1} ms)\n\n".format(
-                        int(misc.round(refresh_rate)), misc.round(1000/refresh_rate, 1)),
+                    "Estimated Screen Refresh Rate:     {0}\n\n".format(
+                        r),
                     text_font="freemono", text_size=int(16 * scaling), text_bold=True,
                     text_justification=0, text_colour=results1_colour, position=(0, int(40 * scaling)))
+        if response !=1:
+            results2_colour = [255, 0, 0]
+        else:
+            results2_colour = [0, 255, 0]
         results2 = stimuli.TextScreen("",
                     "Detected Framebuffer Pages:        {0}\n\n".format(response+1),
                     text_font="freemono", text_size=int(16 * scaling), text_bold=True,
-                    text_justification=0, position=(0, int(20 * scaling)))
+                    text_justification=0, text_colour=results2_colour, position=(0, int(20 * scaling)))
         if inaccuracy > 2:
             results3_colour = [255, 0, 0]
         elif inaccuracy in (1, 2):

--- a/expyriment/control/_test_suite.py
+++ b/expyriment/control/_test_suite.py
@@ -380,14 +380,19 @@ After the test, you will be asked to indicate which (if any) of those two square
 def _audio_playback(exp):
     """Test the audio playback"""
 
+    # Get audio device
+    options = misc.get_audio_devices()
+    menu = io.TextMenu("Audio device", menu_items=options)
+    audio_device = options[menu.get()]
+
     audio_formats = []
-    hz = (44100, 48000, 96000)
-    bits = (-16, -24, -32)
+    hz = (44100, 48000, 88200, 96000)
+    bits = ((-16, "16-bit"), (32, "32-bit float"))
     for x in bits:
         for y in hz:
             try:
                 pygame.mixer.quit()
-                pygame.mixer.pre_init(y, x, 2, 512, allowedchanges=pygame.AUDIO_ALLOW_FREQUENCY_CHANGE)
+                pygame.mixer.pre_init(y, x[0], 2, 512, devicename=audio_device)
                 pygame.mixer.init()
                 audio_formats.append((y, x))
             except:
@@ -402,7 +407,7 @@ def _audio_playback(exp):
         scaling = 2
 
     # Get samplerate, bitrate
-    options = [f"{x[0]} Hz, {x[1] * -1} bit" for x in audio_formats]
+    options = [f"{x[0]} Hz, {x[1][1]}" for x in audio_formats]
     default = (control.defaults.audiosystem_sample_rate,
                control.defaults.audiosystem_bit_depth)
     if default in audio_formats:
@@ -425,7 +430,7 @@ def _audio_playback(exp):
     settings = \
         f"{audio_formats[0]} Hz, {audio_format[1]} bit, {buffer_size} samples"
     pygame.mixer.quit()
-    pygame.mixer.pre_init(audio_format[0], audio_format[1], 2, buffer_size)
+    pygame.mixer.pre_init(audio_format[0], audio_format[1][0], 2, buffer_size)
     pygame.mixer.init()
     pygame.mixer.init()
 

--- a/expyriment/control/_test_suite.py
+++ b/expyriment/control/_test_suite.py
@@ -380,23 +380,32 @@ After the test, you will be asked to indicate which (if any) of those two square
 def _audio_playback(exp):
     """Test the audio playback"""
 
+    info = f"""This will test the auditory stimulus presentation capabilities of your system.
+You will be asked to select the audio device, format, and buffer size to test. Afterwards, a test tone will be played back to you with the chosen settings.
+
+[Press RETURN to continue]
+"""
+    text = stimuli.TextScreen(f"Auditory stimulus presentation test", info)
+    while True:
+        text.present()
+        key, rt_ = exp.keyboard.wait([constants.K_RETURN])
+        if key is not None:
+            break
+
     # Get audio device
     options = misc.get_audio_devices()
     menu = io.TextMenu("Audio device", menu_items=options)
     audio_device = options[menu.get()]
 
-    audio_formats = []
-    hz = (44100, 48000, 88200, 96000)
-    bits = ((-16, "16-bit"), (32, "32-bit float"))
-    for x in bits:
-        for y in hz:
-            try:
-                pygame.mixer.quit()
-                pygame.mixer.pre_init(y, x[0], 2, 512, devicename=audio_device)
-                pygame.mixer.init()
-                audio_formats.append((y, x))
-            except:
-                break
+    # Get sample rate
+    sample_rates = (22050, 44100, 48000, 88200, 96000, 192000)
+    bit_depths = ((8, "8-bit signed integer (8-bit audio)"),
+                 (-8, "8-bit unsigned integer (uncommon)"),
+                 (16, "16-bit signed integer (uncommon)"),
+                 (-16, "16-bit unsigned integer (16-bit audio)"),
+                 (32, "32-bit floating point (23-bit float audio)"))
+    channel_counts = (1, 2, 4 ,6)
+
     buffer_sizes = [32, 64, 128, 256, 512, 1024, 2048, 4096]
 
     # Scale fonts/logo according to default font size
@@ -406,19 +415,52 @@ def _audio_playback(exp):
     if scaling > 2:
         scaling = 2
 
-    # Get samplerate, bitrate
-    options = [f"{x[0]} Hz, {x[1][1]}" for x in audio_formats]
-    default = (control.defaults.audiosystem_sample_rate,
-               control.defaults.audiosystem_bit_depth)
-    if default in audio_formats:
-        index = audio_formats.index(default)
+    # Get samplerate, bitrate for common parameters
+    common = [(sample_rates[1], bit_depths[3], channel_counts[1]),
+              (sample_rates[2], bit_depths[3], channel_counts[1])]
+    default = control.defaults.audiosystem_sample_rate
+    if default in [x[0] for x in common]:
+        index = [x[0] for x in common].index(default)
     else:
-        index = 0
+        index = 2
+    options = [f"{x[0]} Hz, {abs(x[1][0])}-bit, {x[2]} ch" for x in common]
+    options.append("Other")
     menu = io.TextMenu("Audio format", menu_items=options)
-    audio_format = audio_formats[menu.get(index)]
+    selection = menu.get(index)
+    if selection < 2:
+        audio_format = common[selection]
+    else:
+        audio_format = []
+        # Get custom samplerate
+        default = control.defaults.audiosystem_sample_rate
+        if default in sample_rates:
+            index = sample_rates.index(default)
+        else:
+            index = 0
+        menu = io.TextMenu("Sample rate",
+                           menu_items=[f"{x}" for x in sample_rates])
+        audio_format.append(sample_rates[menu.get(index)])
+        # Get custom bit depth
+        default = control.defaults.audiosystem_bit_depth
+        if default in [x[0] for x in bit_depths]:
+            index = [x[0] for x in bit_depths].index(default)
+        else:
+            index = 0
+        menu = io.TextMenu("Bit depth",
+                           menu_items=[f"{x[0]}" for x in bit_depths])
+        audio_format.append(bit_depths[menu.get(index)])
+        # Get channels
+        default = control.defaults.audiosystem_channels
+        if default in channel_counts:
+            index = channel_counts.index(default)
+        else:
+            index = 0
+        menu = io.TextMenu("Channels",
+                           menu_items=[f"{x}" for x in channel_counts])
+        audio_format.append(channel_counts[menu.get(index)])
 
     # Get buffer size
-    options = [f"{x} samples" for x in buffer_sizes]
+    options = [f"{x}" for x in buffer_sizes]
     default = control.defaults.audiosystem_buffer_size
     if default in buffer_sizes:
         index = buffer_sizes.index(default)
@@ -427,18 +469,27 @@ def _audio_playback(exp):
     menu = io.TextMenu("Buffer size", menu_items=options)
     buffer_size = buffer_sizes[menu.get(index)]
 
+    ch = "channel"
+    if audio_format[2] > 1:
+        ch += "s"
     settings = \
-        f"{audio_formats[0]} Hz, {audio_format[1]} bit, {buffer_size} samples"
+        f"{audio_format[0]} Hz, {audio_format[1][1]}, {audio_format[2]} {ch}, {buffer_size} samples"
     pygame.mixer.quit()
-    pygame.mixer.pre_init(audio_format[0], audio_format[1][0], 2, buffer_size)
+    pygame.mixer.pre_init(audio_format[0], audio_format[1][0], audio_format[2],
+                          buffer_size)
     pygame.mixer.init()
     pygame.mixer.init()
 
-    info = f"""This will test the audio playback. A test tone will be played.
+    info = f"""A test tone will now be played with the following audio settings:
+
+{audio_device}
+{settings}
+
+Listen carefully to whether you can hear the tone clearly and undistorded.
 
 [Press RETURN to continue]
 """
-    text = stimuli.TextScreen(f"Audio playback test [settings]", info)
+    text = stimuli.TextScreen(f"Audio playback test", info)
     while True:
         text.present()
         key, rt_ = exp.keyboard.wait([constants.K_RETURN])
@@ -449,7 +500,8 @@ def _audio_playback(exp):
     a = stimuli.Tone(duration=1000)
     a.present()
     exp.clock.wait(1000)
-    text = stimuli.TextScreen("Did you hear the tone?", "[Press Y or N]")
+    text = stimuli.TextScreen("Did you hear the tone clearly and undistorted?",
+                              "[Press Y or N]")
     while True:
         text.present()
         key, _rt = exp.keyboard.wait([constants.K_y,

--- a/expyriment/control/defaults.py
+++ b/expyriment/control/defaults.py
@@ -5,10 +5,21 @@ Default settings for the control package. ::
         start the audiosystem when Expyriment is initialized
 
     audiosystem_bit_depth : int
-        the audio bit depth; negative values mean signed sample values
+        8   = 8 bit unsigned integer (8-bit PCM)
+        -8  = 8 bit signed integer (uncommon)
+        16  = 16 bit unsigned integer (uncommon)
+        -16 = 16 bit signed integer (16-bit PCM)
+        32  = 32 bit floating point (32-bit float PCM)
 
     audiosystem_buffer_size: int
         the audio buffer size in samples
+
+        NOTE
+        ====
+        Smaller buffer sizes reduce the delay in audio playback, but a too
+        small buffer size might result in distorted audio. The optimal buffer
+        size is the smallest one that does not distort the audio, and can
+        differ between systems.
 
     audiosystem_channels : int
         the number of audio channels
@@ -170,7 +181,7 @@ audiosystem_autostart = True
 audiosystem_sample_rate = 44100
 audiosystem_bit_depth = -16  # Negative values mean signed sample values
 audiosystem_channels = 2
-audiosystem_buffer_size = 2048
+audiosystem_buffer_size = 512
 audiosystem_device = None
 
 _mode_settings = None

--- a/expyriment/control/defaults.py
+++ b/expyriment/control/defaults.py
@@ -13,6 +13,9 @@ Default settings for the control package. ::
     audiosystem_channels : int
         the number of audio channels
 
+    audiosystem_device : str
+        the name of the audio device to use
+
     audiosystem_sample_rate : int
         the audio sample rate
 
@@ -168,6 +171,7 @@ audiosystem_sample_rate = 44100
 audiosystem_bit_depth = -16  # Negative values mean signed sample values
 audiosystem_channels = 2
 audiosystem_buffer_size = 2048
+audiosystem_device = None
 
 _mode_settings = None
 

--- a/expyriment/control/defaults.py
+++ b/expyriment/control/defaults.py
@@ -5,11 +5,11 @@ Default settings for the control package. ::
         start the audiosystem when Expyriment is initialized
 
     audiosystem_bit_depth : int
-        8   = 8 bit unsigned integer (8-bit PCM)
+        8   = 8 bit unsigned integer (8-bit audio)
         -8  = 8 bit signed integer (uncommon)
         16  = 16 bit unsigned integer (uncommon)
-        -16 = 16 bit signed integer (16-bit PCM)
-        32  = 32 bit floating point (32-bit float PCM)
+        -16 = 16 bit signed integer (16-bit audio)
+        32  = 32 bit floating point (32-bit float audio)
 
     audiosystem_buffer_size: int
         the audio buffer size in samples

--- a/expyriment/io/_textinput.py
+++ b/expyriment/io/_textinput.py
@@ -9,12 +9,9 @@ __author__ = 'Florian Krause <florian@expyriment.org>, \
 Oliver Lindemann <oliver@expyriment.org>'
 
 import pygame
-try:
-    import android
-except ImportError:
-    android = None
 
 try:
+    import android
     import android.show_keyboard as android_show_keyboard
     import android.hide_keyboard as android_hide_keyboard
 except ImportError:
@@ -23,7 +20,7 @@ except ImportError:
 from . import defaults
 from .. import _internals, stimuli
 from ..misc import find_font, unicode2byte, constants, \
-                 numpad_digit_code2ascii
+                 numpad_digit_code2ascii, is_android_running
 from .._internals import CallbackQuitEvent
 from ._input_output import Input
 
@@ -503,7 +500,7 @@ class TextInput(Input):
                 elif inkey not in (pygame.K_LCTRL, pygame.K_RCTRL,
                                    pygame.K_TAB):
                     if not self._user_text_surface_size[0] >= self._max_size[0]:
-                        if android is not None:
+                        if is_android_running():
                             if inkey in filter:
                                 if inkey in constants.K_ALL_KEYPAD_DIGITS:
                                     inkey = numpad_digit_code2ascii(inkey)

--- a/expyriment/io/_textmenu.py
+++ b/expyriment/io/_textmenu.py
@@ -166,15 +166,13 @@ class TextMenu(Input):
                 text_justification=justification,
                 size=self._line_size))
             stimuli._stimulus.Stimulus._id_counter -= 1
-        self._heading = stimuli.TextBox(
+        self._heading = stimuli.TextLine(
             heading,
             text_size=text_size,
-            text_justification=justification,
             text_font=heading_font,
             text_colour=heading_text_colour,
             text_bold=True,
-            background_colour=self._bkg_colours[0],
-            size=self._line_size)
+            background_colour=self._bkg_colours[0])
         stimuli._stimulus.Stimulus._id_counter -= 1
 
     @property

--- a/expyriment/misc/__init__.py
+++ b/expyriment/misc/__init__.py
@@ -16,7 +16,8 @@ from ._miscellaneous import get_monitor_resolution, get_display_info, \
                             is_idle_running, is_ipython_running, \
                             is_android_running, is_interactive_mode, \
                             create_colours, has_internet_connection, which, \
-                            download_from_stash,string_sort_array, round
+                            download_from_stash,string_sort_array, round, \
+                            get_audio_devices
 from ._get_system_info import get_system_info
 from ._secure_hash import get_module_hash_dictionary, \
                           get_experiment_secure_hash, module_hashes_as_string

--- a/expyriment/misc/_miscellaneous.py
+++ b/expyriment/misc/_miscellaneous.py
@@ -16,6 +16,7 @@ import glob
 import random
 import colorsys
 import math
+import platform
 
 import pygame
 try:
@@ -23,7 +24,7 @@ try:
 except:
     sdl2_audio = None
 
-from .._internals import android, get_settings_folder, get_version, is_venv
+from .._internals import get_settings_folder, get_version, is_venv
 
 try:
     from locale import getdefaultlocale
@@ -361,7 +362,7 @@ def is_idle_running():
 
 
 def is_interactive_mode():
-    """Returns if Python is running in interactive mode (such as IDLE or
+    """Return if Python is running in interactive mode (such as IDLE or
     IPthon)
 
     Returns
@@ -377,7 +378,7 @@ def is_interactive_mode():
 def is_android_running():
     """Return True if Exypriment runs on Android."""
 
-    return android is not None
+    return hasattr(sys, "getandroidapilevel")
 
 
 def has_internet_connection():

--- a/expyriment/misc/_miscellaneous.py
+++ b/expyriment/misc/_miscellaneous.py
@@ -18,6 +18,10 @@ import colorsys
 import math
 
 import pygame
+try:
+    import pygame._sdl2.audio as sdl2_audio
+except:
+    sdl2_audio = None
 
 from .._internals import android, get_settings_folder, get_version, is_venv
 
@@ -557,7 +561,8 @@ def string_sort_array(array):
 
     Returns
     -------
-    array: the sorted array
+    array : list
+        the sorted array
 
     """
 
@@ -570,3 +575,32 @@ def _sorter_fnc(x):
         return str("")
     else:
         return str(x)
+
+def get_audio_devices(input_devices=False):
+    """Get the names of available audio devices.
+
+    Parameters
+    ----------
+    input_devices : bool, optional
+        return input (instead of output) device names (default=False)
+
+    Returns
+    -------
+    audio_devices : list
+        a list of audio device names
+
+    """
+
+    if sdl2_audio is None:
+        return
+
+    is_initialized = pygame.mixer.get_init()
+    if not is_initialized:
+        pygame.mixer.init()
+
+    audio_devices = sdl2_audio.get_audio_device_names(input_devices)
+
+    if not is_initialized:
+        pygame.mixer.quit()
+
+    return audio_devices

--- a/expyriment/misc/_miscellaneous.py
+++ b/expyriment/misc/_miscellaneous.py
@@ -16,7 +16,6 @@ import glob
 import random
 import colorsys
 import math
-import platform
 
 import pygame
 try:

--- a/expyriment/stimuli/_audio.py
+++ b/expyriment/stimuli/_audio.py
@@ -37,11 +37,9 @@ class Audio(Stimulus):
         Parameters
         ----------
         filename : str
-            the filename. Must be an .ogg or uncompressed .wav file.
+            filename (incl. path) of the audio file
 
         """
-        if os.path.splitext(filename)[1] not in ('.wav', '.ogg'):
-            raise ValueError("The audio file must be an .ogg or uncompressed .wav file")
 
         Stimulus.__init__(self, filename)
         self._filename = filename
@@ -96,11 +94,7 @@ class Audio(Stimulus):
         """Preload stimulus to memory."""
 
         if not self._is_preloaded:
-        # Due to a bug in handling file names in PyGame 1.9.2, we pass a file
-        # handle to PyGame. See also:
-        # https://github.com/expyriment/expyriment/issues/81
-            with open(self._filename, 'rb') as f:
-                self._file = mixer.Sound(f)
+            self._file = mixer.Sound(self._filename)
             self._is_preloaded = True
 
     def unload(self, **kwargs):

--- a/expyriment/stimuli/_audio.py
+++ b/expyriment/stimuli/_audio.py
@@ -87,8 +87,16 @@ class Audio(Stimulus):
         return rtn
 
     def preload(self):
-        """Preload stimulus to memory."""
+        """Preload stimulus to memory.
 
+        Returns
+        -------
+        time : int
+            the time it took to execute this method
+
+        """
+
+        start = get_time()
         if not self._is_preloaded:
             # Due to a bug in handling file names introduced in PyGame 1.9.2,
             # we pass a file handle to PyGame. See also:
@@ -97,17 +105,27 @@ class Audio(Stimulus):
                 self._file = pygame.mixer.Sound(f)
             self._is_preloaded = True
 
+        return int((get_time() - start) * 1000)
+
     def unload(self, **kwargs):
         """Unload stimulus from memory.
 
         This removes the reference to the object in memory.
         It is up to the garbage collector to actually remove it from memory.
 
+        Returns
+        -------
+        time : int
+            the time it took to execute this method
+
         """
 
+        start = get_time()
         if self._is_preloaded:
             self._file = None
             self._is_preloaded = False
+
+        return int((get_time() - start) * 1000)
 
     def play(self, loops=0, maxtime=0, fade_ms=0, log_event_tag=None):
         """Play the audio stimulus.

--- a/expyriment/stimuli/_audio.py
+++ b/expyriment/stimuli/_audio.py
@@ -10,8 +10,11 @@ Oliver Lindemann <oliver@expyriment.org>'
 
 import os
 
+import pygame
+
 from .. import _internals
 from ..misc import unicode2byte
+from ..misc._timer import get_time
 from ._stimulus import Stimulus
 
 

--- a/expyriment/stimuli/_audio.py
+++ b/expyriment/stimuli/_audio.py
@@ -10,10 +10,6 @@ Oliver Lindemann <oliver@expyriment.org>'
 
 import os
 
-try:
-    import android.mixer as mixer
-except Exception:
-    import pygame.mixer as mixer
 from .. import _internals
 from ..misc import unicode2byte
 from ._stimulus import Stimulus
@@ -98,7 +94,7 @@ class Audio(Stimulus):
             # we pass a file handle to PyGame. See also:
             # https://github.com/expyriment/expyriment/issues/81
             with open(self._filename, 'rb') as f:
-                self._file = mixer.Sound(f)
+                self._file = pygame.mixer.Sound(f)
             self._is_preloaded = True
 
     def unload(self, **kwargs):

--- a/expyriment/stimuli/_audio.py
+++ b/expyriment/stimuli/_audio.py
@@ -94,7 +94,11 @@ class Audio(Stimulus):
         """Preload stimulus to memory."""
 
         if not self._is_preloaded:
-            self._file = mixer.Sound(self._filename)
+            # Due to a bug in handling file names introduced in PyGame 1.9.2,
+            # we pass a file handle to PyGame. See also:
+            # https://github.com/expyriment/expyriment/issues/81
+            with open(self._filename, 'rb') as f:
+                self._file = mixer.Sound(f)
             self._is_preloaded = True
 
     def unload(self, **kwargs):

--- a/expyriment/stimuli/_video.py
+++ b/expyriment/stimuli/_video.py
@@ -72,9 +72,9 @@ class Video(_visual.Stimulus):
         Parameters
         ----------
         filename : str
-            filename (incl. path) of the video
+            filename (incl. path) of the video file
         audio_backend : str, optional
-            the audio backend to use (one of "pygame" or "sounddevice")
+            audio backend to use (one of "pygame" or "sounddevice")
         position : (int, int), optional
             position of the stimulus
 

--- a/expyriment/stimuli/_video.py
+++ b/expyriment/stimuli/_video.py
@@ -20,6 +20,7 @@ except Exception:
 
 from . import defaults
 from . import _visual
+from ..control import defaults as control_defaults
 from ..misc import unicode2byte, Clock, has_internet_connection, which
 from .._internals import CallbackQuitEvent
 from .. import _internals
@@ -135,6 +136,16 @@ class Video(_visual.Stimulus):
                 self._backend = "pygame"
             try:
                 import sounddevice as _sounddevice
+                # Set output device from control.defaults
+                default_device = control_defaults.audiosystem_device
+                if default_device is not None:
+                    device_id = None
+                    for device in _sounddevice.query_devices():
+                        if device["name"] in default_device:  # can be cut off
+                            if device["max_output_channels"] > 0: # output device
+                                device_id = device["index"]
+                    if device_id is not None:
+                        _sounddevice.default.device = None, device_id
             except ImportError:
                 print("Warning: Package 'sounddevice' not installed!\n" +
                       "Audio will be played back using Pygame audiosystem.")

--- a/expyriment/stimuli/_video.py
+++ b/expyriment/stimuli/_video.py
@@ -396,7 +396,7 @@ class Video(_visual.Stimulus):
             self._file.seek(0)
             self._frame = 0
             self._start_position = 0
-            if self._file.audioformat:
+            if self._file.audioformat and hasattr(self, "_audio"):
                 self._audio.close_stream()
 
     def pause(self):

--- a/expyriment/stimuli/_video.py
+++ b/expyriment/stimuli/_video.py
@@ -111,7 +111,7 @@ class Video(_visual.Stimulus):
         except ImportError:
             raise ImportError(
                 "Video playback needs the package 'mediadecoder'." +
-                "\nPlease install mediadecoder(>=0.1.6,<1).")
+                "\nPlease install mediadecoder(>=0.2,<1).")
 
         if self._audio_backend == "sounddevice":
             try:

--- a/expyriment/stimuli/_visual.py
+++ b/expyriment/stimuli/_visual.py
@@ -205,6 +205,7 @@ class Visual(Stimulus):
             width, height = len(surf[0]), len(surf)
         ogl.glEnable(ogl.GL_TEXTURE_2D)
         ogl.glBindTexture(ogl.GL_TEXTURE_2D, txtr)
+        ogl.glPixelStorei(ogl.GL_UNPACK_ALIGNMENT, 1)
         ogl.glTexImage2D(ogl.GL_TEXTURE_2D, 0, colours, width, height, 0,
           colours, ogl.GL_UNSIGNED_BYTE, textureData)
         ogl.glTexParameterf(ogl.GL_TEXTURE_2D,

--- a/expyriment/stimuli/defaults.py
+++ b/expyriment/stimuli/defaults.py
@@ -101,7 +101,6 @@ picture_position = (0, 0)
 
 # Video
 video_position = [0, 0]
-video_backend = "mediadecoder"  # 'mediadecoder' or 'pygame'
 
 # Tone
 tone_frequency = 440

--- a/expyriment/stimuli/defaults.py
+++ b/expyriment/stimuli/defaults.py
@@ -100,6 +100,7 @@ rectangle_corner_anti_aliasing = 0
 picture_position = (0, 0)
 
 # Video
+video_resizing = (None, None)
 video_audio_backend = "pygame"
 video_position = [0, 0]
 

--- a/expyriment/stimuli/defaults.py
+++ b/expyriment/stimuli/defaults.py
@@ -100,6 +100,7 @@ rectangle_corner_anti_aliasing = 0
 picture_position = (0, 0)
 
 # Video
+video_audio_backend = "pygame"
 video_position = [0, 0]
 
 # Tone

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,16 +26,12 @@ all = [
   "numpy>=1.6,<3",
   "pyserial>=3,<4",
   "pyparallel>=0.2,<1",
-  "sounddevice>=0.3,<1",
-  "mediadecoder>=0.1,<1",
+  "mediadecoder>=0.1.6,<1",
 ]
 data_preprocessing = ["numpy>=1.6,<3"]
 parallelport_linux = ["pyparallel>=0.2,<1"]
 serialport = ["pyserial>=3,<4"]
-video = [
-  "sounddevice>=0.3,<1",
-  "mediadecoder>=0.1,<1",
-]
+video = ["mediadecoder>=0.1.6,<1"]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/expyriment/expyriment/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,12 @@ all = [
   "numpy>=1.6,<3",
   "pyserial>=3,<4",
   "pyparallel>=0.2,<1",
-  "mediadecoder>=0.1.6,<1",
+  "mediadecoder>=0.2,<1",
 ]
 data_preprocessing = ["numpy>=1.6,<3"]
 parallelport_linux = ["pyparallel>=0.2,<1"]
 serialport = ["pyserial>=3,<4"]
-video = ["mediadecoder>=0.1.6,<1"]
+video = ["mediadecoder>=0.2,<1"]
 
 [project.urls]
 "Bug Tracker" = "https://github.com/expyriment/expyriment/issues"


### PR DESCRIPTION
- audiosystem:
    - support for selecting audio device
    - new control default ``audiosystem_device``
    - new function ``misc.get_audio_devices``
   
- stimuli.Video:
    - general improvements
    - Pygame video backend removed (always relies on mediadecoder)
    - Pygame audio backend is now the default (instead of sounddevice)
    - new parameter ``audio_backend``
    - new stimuli default ``video_audio_backend``
    - Pygame audio backend uses current audiosystem (if started)

**NOTE**: This depends on a future release of mediadecoder with these changes: https://github.com/open-cogsci/python-mediadecoder/pull/6. That is, this code will NOT run correctly with the current dependencies. 