### PR TITLE
Apply ruff/flake8-comprehensions rule (C416)

### DIFF
--- a/expyriment/misc/data_preprocessing/_data_preprocessing.py
+++ b/expyriment/misc/data_preprocessing/_data_preprocessing.py
@@ -730,7 +730,7 @@ The Python package 'Numpy' is not installed."""
 
         print(u"found {0} subject_data sets".format(len(self._data_files)))
         print(u"found {0} variables: {1}".format(len(self._variables),
-                                                 [x for x in self._variables]))
+                                                 list(self._variables)))
 
     @property
     def data_files(self):


### PR DESCRIPTION
C416 Unnecessary list comprehension (rewrite using `list()`)