### PR TITLE
Apply ruff/Pylint Error rules (PLE)

### DIFF
--- a/expyriment/misc/_get_system_info.py
+++ b/expyriment/misc/_get_system_info.py
@@ -254,7 +254,7 @@ def get_system_info(as_string=False):
                 def __init__(self):
                     # Initialize this to the size of MEMORYSTATUSEX
                     self.dwLength = 2 * 4 + 7 * 8  # size = 2 ints, 7 longs
-                    return super(MEMORYSTATUSEX, self).__init__()
+                    super(MEMORYSTATUSEX, self).__init__()
 
             stat = MEMORYSTATUSEX()
             ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(stat))


### PR DESCRIPTION
[PLE0101](https://docs.astral.sh/ruff/rules/return-in-init/) Explicit return in `__init__`