### PR TITLE
Add ruff configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,3 +39,50 @@ dependencies = [
 
 [project.scripts]
 expyriment="expyriment.cli:main"
+
+[tool.ruff.lint]
+extend-select = [
+    "B",
+    "C4",
+    "EXE",
+    "PIE",
+    "PYI",
+    "SIM",
+    "FLY",
+    #"I",
+    "PGH",
+    "PLE",
+    "PLW",
+    "UP",
+]
+ignore = [
+    "B018",
+    "B026",
+    "B904",
+    "B905",
+    "C417",
+    "PIE790",
+    "PIE808",
+    "SIM102",
+    "SIM103",
+    "SIM105",
+    "SIM108",
+    "SIM114",
+    "SIM115",
+    "SIM117",
+    "SIM118",
+    "PLW0603",
+    "PLW2901",
+    "PLW0602",
+    "E402",
+    "E741",
+    "F401",
+    "F811",
+    "F821",
+    "F841",
+    "PLW1641",
+    "UP015",
+    "UP030",
+    "UP031",
+    "UP032",
+]


### PR DESCRIPTION
In addition to the default rules (`F` and subset of `E`), I have added the rulesets you seemed to approve in previous PRs.

I have left out `W` rules for now. They are redundant with the use of a formatter, the use of which I suggest in #249.

I have also left out `N` rules (PEP8 naming), to be applied later.

I will enable `I` rules once #248 is merged.

Eventually, I'd like to apply Scientific Python suggestions that make sense:
[**Repo-Review**](https://learn.scientific-python.org/development/guides/repo-review/?repo=expyriment%2Fexpyriment&ref=master&refType=branch)