### PR TITLE
`int(round(x))` → `round(x)`

### DIFF
--- a/expyriment/misc/_colour.py
+++ b/expyriment/misc/_colour.py
@@ -456,7 +456,7 @@ class Colour:
 
 # Helper functions
 def multiply(v, d):
-    return tuple(map(lambda x:int(round(x*d)), v))
+    return tuple(map(lambda x:round(x*d), v))
 
 def divide(v, d):
     return tuple(map(lambda x:x/float(d), v))

--- a/expyriment/misc/_miscellaneous.py
+++ b/expyriment/misc/_miscellaneous.py
@@ -138,8 +138,8 @@ class MediaTime(float):
         return float(self) >= self.convert_to_seconds(other)
 
 
-def round(number, ndigits=0): # TODO: overrides Python's round, maybe renaming?
-    """Round half away from zero.
+def _py2_round(number, ndigits=0):
+    """Round half away from zero and always return a float.
 
     This method implements the Python 2 way of rounding.
     For "bankers rounding" (round half to even), please use the builtin `round`
@@ -568,8 +568,8 @@ def download_from_stash(content="all", branch=None):
 
     def show_progress(count, total, status=''):
         bar_len = 40
-        filled_len = int(round(bar_len * count / float(total)))
-        percents = round(100.0 * count / float(total), 1)
+        filled_len = int(_py2_round(bar_len * count / float(total)))
+        percents = _py2_round(100.0 * count / float(total), 1)
         bar = '=' * filled_len + ' ' * (bar_len - filled_len)
         sys.stdout.write('{:5.1f}% [{}] {}\r'.format(percents, bar, status))
         sys.stdout.flush()


### PR DESCRIPTION
* The built-in `round()` readily returns an int.
* Avoid hiding the built-in `round()` as this is confusing.